### PR TITLE
fix : 알림톡 순서 보장하도록 수정

### DIFF
--- a/src/main/java/com/yedu/backend/global/bizppurio/application/mapper/BizppurioMapper.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/mapper/BizppurioMapper.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 @Component
-@RequiredArgsConstructor
 public class BizppurioMapper {
     @Value("${bizppurio.id}")
     private String id;

--- a/src/main/java/com/yedu/backend/global/bizppurio/application/mapper/BizppurioMapper.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/mapper/BizppurioMapper.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 @Component
+@RequiredArgsConstructor
 public class BizppurioMapper {
     @Value("${bizppurio.id}")
     private String id;
@@ -108,7 +109,7 @@ public class BizppurioMapper {
         return createCommonRequest(messageBody, teacher.getTeacherInfo().getPhoneNumber());
     }
 
-    public CommonRequest mapToApplyPhotoSubmit(Teacher teacher) {
+    public CommonRequest mapToApplyPhotoSubmit(String phoneNumber) {
         String message = ("지원서는 Y-Edu가 프로필로 만들어, 이후 매칭 시 학부모님께 전달드릴게요. \n" +
                 "\n" +
                 "다음 단계는 프로필 사진과 영상을 구글폼으로 제출해 주세요. \uD83D\uDE42\n" +
@@ -128,7 +129,7 @@ public class BizppurioMapper {
                 "사진과 영상은 꼭 3일 이내 제출해주세요!");
         CommonButton webLinkButton = new WebButton("사진/영상 제출하기", WEB_LINK, photoSubmitUrl, photoSubmitUrl);
         Message messageBody = new ButtonMessage(message, yeduApplyKey, applyPhotoSubmit, new CommonButton[]{webLinkButton});
-        return createCommonRequest(messageBody, teacher.getTeacherInfo().getPhoneNumber());
+        return createCommonRequest(messageBody, phoneNumber);
     }
 
     public CommonRequest mapToPhotoHurry(Teacher teacher) {

--- a/src/main/java/com/yedu/backend/global/bizppurio/application/usecase/BizppurioCheckStep.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/usecase/BizppurioCheckStep.java
@@ -1,0 +1,31 @@
+package com.yedu.backend.global.bizppurio.application.usecase;
+
+import com.yedu.backend.global.bizppurio.application.dto.req.MessageStatusRequest;
+import com.yedu.backend.global.config.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class BizppurioCheckStep {
+    private final RedisRepository redisRepository;
+    private final BizppurioTeacherMessage teacherMessage;
+
+    private static final String COUNSEL = "COUNSEL";
+
+    public void checkNextStep(MessageStatusRequest request) {
+        getCacheValue(request.REFKEY()).ifPresent(stepValue -> processNextStep(stepValue, request.PHONE()));
+    }
+
+    private Optional<String> getCacheValue(String refKey) {
+        return redisRepository.getValues(refKey);
+    }
+
+    private void processNextStep(String stepValue, String phone) {
+        if (COUNSEL.equals(stepValue)) {
+            teacherMessage.photoSubmit(phone);
+        }
+    }
+}

--- a/src/main/java/com/yedu/backend/global/bizppurio/application/usecase/BizppurioTeacherMessage.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/usecase/BizppurioTeacherMessage.java
@@ -2,24 +2,34 @@ package com.yedu.backend.global.bizppurio.application.usecase;
 
 import com.yedu.backend.domain.parents.domain.entity.ApplicationForm;
 import com.yedu.backend.domain.teacher.domain.entity.Teacher;
+import com.yedu.backend.domain.teacher.domain.service.TeacherGetService;
+import com.yedu.backend.global.bizppurio.application.dto.req.CommonRequest;
 import com.yedu.backend.global.bizppurio.application.mapper.BizppurioMapper;
+import com.yedu.backend.global.config.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
 
 @RequiredArgsConstructor
 @Component
 public class BizppurioTeacherMessage {
     private final BizppurioMapper bizppurioMapper;
     private final BizppurioSend bizppurioSend;
+    private final RedisRepository redisRepository;
+    private static final String COUNSEL = "COUNSEL";
 
     public void counselStartAndPhotoSubmit(Teacher teacher) {
-        bizppurioSend.sendMessageWithExceptionHandling(() -> bizppurioMapper.mapToCounselStart(teacher))
-                .block();
-        photoSubmit(teacher);
+        bizppurioSend.sendMessageWithExceptionHandling(() -> {
+                    CommonRequest request = bizppurioMapper.mapToCounselStart(teacher);
+                    redisRepository.setValues(request.refkey(), COUNSEL, Duration.ofMinutes(1));
+                    return request;
+                })
+                .subscribe();
     }
 
-    private void photoSubmit(Teacher teacher) {
-        bizppurioSend.sendMessageWithExceptionHandling(() -> bizppurioMapper.mapToApplyPhotoSubmit(teacher)).subscribe();
+    public void photoSubmit(String phoneNumber) {
+        bizppurioSend.sendMessageWithExceptionHandling(() -> bizppurioMapper.mapToApplyPhotoSubmit(phoneNumber)).subscribe();
     }
 
     public void photoHurry(Teacher teacher) {

--- a/src/main/java/com/yedu/backend/global/bizppurio/presentation/BizppurioController.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/presentation/BizppurioController.java
@@ -1,6 +1,7 @@
 package com.yedu.backend.global.bizppurio.presentation;
 
 import com.yedu.backend.global.bizppurio.application.dto.req.MessageStatusRequest;
+import com.yedu.backend.global.bizppurio.application.usecase.BizppurioCheckStep;
 import com.yedu.backend.global.bizppurio.application.usecase.BizppurioSend;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,9 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/bizppurio")
 public class BizppurioController {
     private final BizppurioSend bizppurioSend;
+    private final BizppurioCheckStep bizppurioCheckStep;
 
     @PostMapping("/result/webhook")
     public void resultWebHook(@RequestBody MessageStatusRequest request) {
         bizppurioSend.checkByWebHook(request);
+        bizppurioCheckStep.checkNextStep(request);
     }
 }


### PR DESCRIPTION
## 🐈 PR 요약
 알림톡 순서 보장하도록 수정

## ✨ PR 상세
- 선생님 상담 시작 알림톡 전송시 Redis에 RefKey 키로 COUNSEL값 저장
- 비즈뿌리오 웹훅 응답시 Refkey키를 Redis에 대조하여 확인
- 만약 Redis에 COUNSEL이라는 값이 저장되어있는 경우 사진 구글폼 요청 알림톡 전송 시작

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## ✅ 체크리스트
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced workflow step that validates the next action based on cached state.
  
- **Refactor**
	- Updated submission and messaging flows to accept direct phone number input.
	- Transitioned to non-blocking operations with integrated caching.
	- Refined webhook handling to include additional process validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->