### PR TITLE
feat : 거절 사유별 알림톡 구분

### DIFF
--- a/src/main/java/com/yedu/backend/domain/matching/application/usecase/ClassMatchingManageUseCase.java
+++ b/src/main/java/com/yedu/backend/domain/matching/application/usecase/ClassMatchingManageUseCase.java
@@ -15,6 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.yedu.backend.domain.matching.domain.entity.constant.RefuseReason.UNABLE_DISTRICT;
+import static com.yedu.backend.domain.matching.domain.entity.constant.RefuseReason.UNABLE_NOW;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -36,8 +39,16 @@ public class ClassMatchingManageUseCase {
         if (!classMatching.isWaiting())
             throw new IllegalArgumentException();
         classMatchingUpdateService.updateRefuse(classMatching, request);
-
         Teacher teacher = classMatching.getTeacher();
+        String refuseReason = request.refuseReason();
+        if (refuseReason.equals(UNABLE_NOW.getReason())) {
+            bizppurioTeacherMessage.refuseCaseNow(teacher);
+            return;
+        }
+        if (refuseReason.equals(UNABLE_DISTRICT.getReason())) {
+            bizppurioTeacherMessage.refuseCaseDistrict(teacher);
+            return;
+        }
         bizppurioTeacherMessage.refuseCase(teacher);
     }
 

--- a/src/main/java/com/yedu/backend/domain/matching/domain/entity/constant/RefuseReason.java
+++ b/src/main/java/com/yedu/backend/domain/matching/domain/entity/constant/RefuseReason.java
@@ -1,0 +1,13 @@
+package com.yedu.backend.domain.matching.domain.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum RefuseReason {
+    UNABLE_NOW("지금은 수업이 불가해요"),
+    UNABLE_DISTRICT("가능한 지역이 아니에요");
+
+    private final String reason;
+}

--- a/src/main/java/com/yedu/backend/global/bizppurio/application/mapper/BizppurioMapper.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/mapper/BizppurioMapper.java
@@ -45,6 +45,10 @@ public class BizppurioMapper {
     private String matchingAcceptCase;
     @Value("${bizppurio.yedu_matching_template.refuse_case}")
     private String matchingRefuseCase;
+    @Value("${bizppurio.yedu_matching_template.refuse_case_now}")
+    private String matchingRefuseCaseNow;
+    @Value("${bizppurio.yedu_matching_template.refuse_case_district}")
+    private String matchingRefuseCaseDistrict;
     @Value("${bizppurio.yedu_matching_template.matching_channel}")
     private String matchingChannel;
     @Value("${bizppurio.yedu_offical_template.recommend_guide}")
@@ -65,6 +69,8 @@ public class BizppurioMapper {
     private String photoHurryUrl;
     @Value("${bizppurio.url.write_application_form}")
     private String writeApplicationFormUrl;
+    @Value("${bizppurio.url.refuse_change_form}")
+    private String refuseChangeFormUrl;
 
     private static final String WEB_LINK = "WL";
     private static final String BOT = "BK";
@@ -229,6 +235,36 @@ public class BizppurioMapper {
                 "요건 수정이나, 과외 공지 중단 요청은 상담 직원에게 말씀해주세요.");
         CommonButton simpleButton = new SimpleButton("상담 매니저에게 요청하기", BOT);
         Message messageBody = new ButtonMessage(message, yeduMatchingKey, matchingRefuseCase, new CommonButton[]{simpleButton});
+        return createCommonRequest(messageBody, teacher.getTeacherInfo().getPhoneNumber());
+    }
+
+    public CommonRequest mapToRefuseCaseNow(Teacher teacher) {
+        String message = ("[과외 가능지역 변경 안내]\n" +
+                "\n" +
+                teacher.getTeacherInfo().getNickName() + " 선생님. \n" +
+                "\n" +
+                "현재 발송되고 있는 과외건 공지가 실제 가능한 지역과 다를 경우, 과외 가능 지역 업데이트가 필요합니다.\n" +
+                "\n" +
+                "아래 버튼을 클릭하여 과외 설정 페이지 접속 후 지역을 변경하실 수 있습니다. \n" +
+                "\n" +
+                "과외 설정을 최신화 하시면, 가능한 지역의 과외건 공지만 받아보실 수 있습니다. \uD83D\uDE09");
+        CommonButton webButton = new WebButton("과외 설정 페이지로 이동", WEB_LINK, refuseChangeFormUrl, refuseChangeFormUrl);
+        Message messageBody = new ButtonMessage(message, yeduMatchingKey, matchingRefuseCase, new CommonButton[]{webButton});
+        return createCommonRequest(messageBody, teacher.getTeacherInfo().getPhoneNumber());
+    }
+
+    public CommonRequest mapToRefuseCaseDistrict(Teacher teacher) {
+        String message = ("[과외 가능지역 변경 안내]\n" +
+                "\n" +
+                teacher.getTeacherInfo().getNickName() + " 선생님.\n" +
+                "\n" +
+                "현재 발송되고 있는 과외건 공지가 실제 가능한 지역과 다를 경우, 과외 가능 지역 업데이트가 필요합니다.\n" +
+                "\n" +
+                "아래 버튼을 클릭하여 과외 설정 페이지 접속 후 지역을 변경하실 수 있습니다.\n" +
+                "\n" +
+                "과외 설정을 최신화 하시면, 가능한 지역의 과외건 공지만 받아보실 수 있습니다. \uD83D\uDE09");
+        CommonButton webButton = new WebButton("과외 설정 페이지로 이동", WEB_LINK, refuseChangeFormUrl, refuseChangeFormUrl);
+        Message messageBody = new ButtonMessage(message, yeduMatchingKey, matchingRefuseCase, new CommonButton[]{webButton});
         return createCommonRequest(messageBody, teacher.getTeacherInfo().getPhoneNumber());
     }
 

--- a/src/main/java/com/yedu/backend/global/bizppurio/application/usecase/BizppurioTeacherMessage.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/usecase/BizppurioTeacherMessage.java
@@ -2,7 +2,6 @@ package com.yedu.backend.global.bizppurio.application.usecase;
 
 import com.yedu.backend.domain.parents.domain.entity.ApplicationForm;
 import com.yedu.backend.domain.teacher.domain.entity.Teacher;
-import com.yedu.backend.domain.teacher.domain.service.TeacherGetService;
 import com.yedu.backend.global.bizppurio.application.dto.req.CommonRequest;
 import com.yedu.backend.global.bizppurio.application.mapper.BizppurioMapper;
 import com.yedu.backend.global.config.redis.RedisRepository;
@@ -58,5 +57,13 @@ public class BizppurioTeacherMessage {
 
     public void refuseCase(Teacher teacher) {
         bizppurioSend.sendMessageWithExceptionHandling(() -> bizppurioMapper.mapToRefuseCase(teacher)).subscribe();
+    }
+
+    public void refuseCaseNow(Teacher teacher) {
+        bizppurioSend.sendMessageWithExceptionHandling(() -> bizppurioMapper.mapToRefuseCaseNow(teacher)).subscribe();
+    }
+
+    public void refuseCaseDistrict(Teacher teacher) {
+        bizppurioSend.sendMessageWithExceptionHandling(() -> bizppurioMapper.mapToRefuseCaseDistrict(teacher)).subscribe();
     }
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/1b3afa1037b280bfa7d2ca1780e03b76
거절 사유별 알림톡 구분

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 분리할 거절 사유 2가지에 대해 Enum 클래스 생성
- Enum클래스 비교 후 해당하는 알림톡 전송

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## ✅ 체크리스트
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced teacher notifications now provide tailored messages for class matching refusals based on different reasons.
  - Added an actionable update option that directs teachers to review and adjust their tutoring region settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->