### PR TITLE
refactor : 알림톡 예외 알림 템플릿 수정

### DIFF
--- a/src/main/java/com/yedu/backend/global/bizppurio/application/dto/req/ContentRequest.java
+++ b/src/main/java/com/yedu/backend/global/bizppurio/application/dto/req/ContentRequest.java
@@ -2,4 +2,4 @@ package com.yedu.backend.global.bizppurio.application.dto.req;
 
 import com.yedu.backend.global.bizppurio.application.dto.req.content.Message;
 
-public record ContentRequest(Message at) {}
+public record ContentRequest(Message message) {}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
 알림톡 예외 알림 템플릿 수정

## ✨ PR 상세
- RefKey 를 Key값으로 Redis에 알림톡 내용 저장 (30초)
- 비즈뿌리오로 부터 수신받은 결과값이 실패인 경우, Redis로 부터 RefKey를 기반으로 조회 후 Discord에 실패한 내용을 추가하여 전송

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## ✅ 체크리스트
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?