### PR TITLE
feat : tally 폼에서 과외 타임 테이블 저장하도록 수정

### DIFF
--- a/api/src/main/java/com/yedu/backend/domain/parents/application/dto/req/ApplicationFormRequest.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/application/dto/req/ApplicationFormRequest.java
@@ -4,6 +4,7 @@ import com.yedu.backend.domain.parents.domain.entity.constant.ClassType;
 import com.yedu.backend.domain.parents.domain.entity.constant.Gender;
 import com.yedu.backend.domain.parents.domain.entity.constant.Online;
 
+import com.yedu.backend.domain.parents.domain.vo.DayTime;
 import java.util.List;
 
 public record ApplicationFormRequest(
@@ -19,6 +20,7 @@ public record ApplicationFormRequest(
         String district,
         String dong,
         String wantTime,
-        String source
+        String source,
+        List<DayTime> dayTimes
 ) {
 }

--- a/api/src/main/java/com/yedu/backend/domain/parents/application/dto/res/ApplicationFormTimeTableResponse.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/application/dto/res/ApplicationFormTimeTableResponse.java
@@ -1,21 +1,14 @@
 package com.yedu.backend.domain.parents.application.dto.res;
 
-import com.yedu.backend.domain.teacher.domain.entity.constant.Day;
-import java.time.LocalTime;
+import com.yedu.backend.domain.parents.domain.vo.DayTime;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record ApplicationFormTimeTableResponse(
     String applicationFormId,
-    List<Time> times
+    List<DayTime> dayTimes
 ) {
-  public record Time(
-      Day day,
-      List<LocalTime> times
-  ){
-
-  }
 
   public static ApplicationFormTimeTableResponse empty() {
     return ApplicationFormTimeTableResponse.builder().build();

--- a/api/src/main/java/com/yedu/backend/domain/parents/application/mapper/ApplicationFormAvailableMapper.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/application/mapper/ApplicationFormAvailableMapper.java
@@ -2,6 +2,7 @@ package com.yedu.backend.domain.parents.application.mapper;
 
 import com.yedu.backend.domain.parents.application.dto.res.ApplicationFormTimeTableResponse;
 import com.yedu.backend.domain.parents.domain.entity.ApplicationFormAvailable;
+import com.yedu.backend.domain.parents.domain.vo.DayTime;
 import com.yedu.backend.domain.teacher.domain.entity.constant.Day;
 import java.time.LocalTime;
 import java.util.List;
@@ -23,13 +24,25 @@ public class ApplicationFormAvailableMapper {
                 Collectors.mapping(ApplicationFormAvailable::getAvailableTime, Collectors.toList())
             ));
 
-        List<ApplicationFormTimeTableResponse.Time> times = groupedByDay.entrySet().stream()
-            .map(entry -> new ApplicationFormTimeTableResponse.Time(entry.getKey(), entry.getValue()))
+        List<DayTime> times = groupedByDay.entrySet().stream()
+            .map(entry -> new DayTime(entry.getKey(), entry.getValue()))
             .toList();
 
         return ApplicationFormTimeTableResponse.builder()
             .applicationFormId(applicationFormAvailables.get(0).getApplicationFormId())
-            .times(times)
+            .dayTimes(times)
             .build();
+    }
+
+    public static List<ApplicationFormAvailable> map(List<DayTime> dayTimes, String applicationFormId) {
+        return dayTimes.stream()
+            .flatMap(dayTime -> dayTime.getTimes().stream()
+                .map(time -> ApplicationFormAvailable.builder()
+                    .applicationFormId(applicationFormId)
+                    .day(dayTime.getDay())
+                    .availableTime(time)
+                    .build()
+                )
+            ).toList();
     }
 }

--- a/api/src/main/java/com/yedu/backend/domain/parents/application/usecase/ParentsManageUseCase.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/application/usecase/ParentsManageUseCase.java
@@ -7,8 +7,10 @@ import com.yedu.backend.domain.parents.application.dto.req.ApplicationFormTimeTa
 import com.yedu.backend.domain.parents.application.dto.res.ApplicationFormTimeTableResponse;
 import com.yedu.backend.domain.parents.application.mapper.ApplicationFormAvailableMapper;
 import com.yedu.backend.domain.parents.domain.entity.ApplicationForm;
+import com.yedu.backend.domain.parents.domain.entity.ApplicationFormAvailable;
 import com.yedu.backend.domain.parents.domain.entity.Goal;
 import com.yedu.backend.domain.parents.domain.entity.Parents;
+import com.yedu.backend.domain.parents.domain.service.ApplicationFormAvailableCommandService;
 import com.yedu.backend.domain.parents.domain.service.ApplicationFormAvailableQueryService;
 import com.yedu.backend.domain.parents.domain.service.ParentsGetService;
 import com.yedu.backend.domain.parents.domain.service.ParentsSaveService;
@@ -38,6 +40,7 @@ public class ParentsManageUseCase {
     private final TeacherInfoUseCase teacherInfoUseCase;
     private final ClassMatchingManageUseCase classMatchingManageUseCase;
     private final ApplicationFormAvailableQueryService applicationFormAvailableQueryService;
+    private final ApplicationFormAvailableCommandService applicationFormAvailableCommandService;
     private final RedisRepository redisRepository;
 
     public void saveParentsAndApplication(ApplicationFormRequest request) {
@@ -50,6 +53,10 @@ public class ParentsManageUseCase {
                 .map(goal -> mapToGoal(applicationForm, goal))
                 .toList();
         parentsSaveService.saveApplication(applicationForm, goals);
+
+        List<ApplicationFormAvailable> applicationFormAvailables = ApplicationFormAvailableMapper.map(request.dayTimes(), applicationForm.getApplicationFormId());
+        applicationFormAvailableCommandService.saveAll(applicationFormAvailables);
+
         List<Teacher> teachers = teacherInfoUseCase.allApplicationFormTeacher(applicationForm);
         List<ClassMatching> classMatchings = classMatchingManageUseCase.saveAllClassMatching(teachers, applicationForm);// 매칭 저장
         teacherManageUseCase.notifyClass(classMatchings); // 선생님한테 알림톡 전송

--- a/api/src/main/java/com/yedu/backend/domain/parents/domain/service/ApplicationFormAvailableCommandService.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/domain/service/ApplicationFormAvailableCommandService.java
@@ -1,0 +1,20 @@
+package com.yedu.backend.domain.parents.domain.service;
+
+import com.yedu.backend.domain.parents.domain.entity.ApplicationFormAvailable;
+import com.yedu.backend.domain.parents.domain.repository.ApplicationFormAvailableRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = false)
+public class ApplicationFormAvailableCommandService {
+
+    private final ApplicationFormAvailableRepository applicationFormAvailableRepository;
+
+    public void saveAll(List<ApplicationFormAvailable> applicationFormAvailables) {
+        applicationFormAvailableRepository.saveAll(applicationFormAvailables);
+    }
+}

--- a/api/src/main/java/com/yedu/backend/domain/parents/domain/vo/DayTime.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/domain/vo/DayTime.java
@@ -1,0 +1,16 @@
+package com.yedu.backend.domain.parents.domain.vo;
+
+import com.yedu.backend.domain.teacher.domain.entity.constant.Day;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DayTime {
+
+  private final Day day;
+
+  private final List<LocalTime> times;
+}

--- a/api/src/main/resources/db/migration/V4_202504172150__alter_matching_timetable_fk.sql
+++ b/api/src/main/resources/db/migration/V4_202504172150__alter_matching_timetable_fk.sql
@@ -1,0 +1,5 @@
+alter table yedu.matching_timetable
+drop column application_form_application_form_id;
+
+alter table yedu.matching_timetable
+    add column class_matching_id bigint;


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/list-e0e0be947a564f3794bc46f988352c73?p=1d5afa1037b280088efbf971db4375d5&pm=s

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- tally 에서 호출되는 API 요청스펙에서 타임테이블 받을수있도록 변경
- 전달받은 타임테이블 저장 
- matching_timetable FK 수정

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성


## ✅ 체크리스트
- [v] Label 지정했나요?
- [v] 관련 테크스펙 링크 연결했나요?