### PR TITLE
fix : 선생님 과외 공지 API 응답 수정

### DIFF
--- a/api/src/main/java/com/yedu/backend/domain/matching/application/dto/res/ClassMatchingForTeacherResponse.java
+++ b/api/src/main/java/com/yedu/backend/domain/matching/application/dto/res/ClassMatchingForTeacherResponse.java
@@ -2,6 +2,7 @@ package com.yedu.backend.domain.matching.application.dto.res;
 
 import com.yedu.backend.domain.matching.domain.entity.constant.MatchingStatus;
 import com.yedu.backend.domain.parents.domain.entity.constant.Online;
+import com.yedu.backend.domain.parents.domain.vo.DayTime;
 import com.yedu.common.type.ClassType;
 import java.util.List;
 
@@ -17,5 +18,5 @@ public record ClassMatchingForTeacherResponse(
     String dong,
     List<String> goals,
     String favoriteStyle,
-    String favoriteTime,
+    List<DayTime> dayTimes,
     MatchingStatus matchStatus) {}

--- a/api/src/main/java/com/yedu/backend/domain/matching/application/mapper/ClassMatchingMapper.java
+++ b/api/src/main/java/com/yedu/backend/domain/matching/application/mapper/ClassMatchingMapper.java
@@ -3,6 +3,7 @@ package com.yedu.backend.domain.matching.application.mapper;
 import com.yedu.backend.domain.matching.application.dto.res.ClassMatchingForTeacherResponse;
 import com.yedu.backend.domain.matching.domain.entity.ClassMatching;
 import com.yedu.backend.domain.parents.domain.entity.ApplicationForm;
+import com.yedu.backend.domain.parents.domain.vo.DayTime;
 import com.yedu.backend.domain.teacher.domain.entity.Teacher;
 import java.util.List;
 
@@ -12,20 +13,20 @@ public class ClassMatchingMapper {
   }
 
   public static ClassMatchingForTeacherResponse mapToApplicationFormToTeacherResponse(
-      ClassMatching classMatching, ApplicationForm applicationForm, List<String> goals) {
+          ClassMatching classMatching, ApplicationForm applicationForm, List<String> goals, List<DayTime> dayTimes) {
     return new ClassMatchingForTeacherResponse(
-        applicationForm.getApplicationFormId(),
-        applicationForm.getWantedSubject(),
-        applicationForm.getAge(),
-        applicationForm.getClassCount(),
-        applicationForm.getClassTime(),
-        (int) (applicationForm.getPay() * (5.0 / 6.0)),
-        applicationForm.getOnline(),
-        applicationForm.getDistrict().getDescription(),
-        applicationForm.getDong(),
-        goals,
-        applicationForm.getFavoriteStyle(),
-        applicationForm.getWantTime(),
-        classMatching.getMatchStatus());
+            applicationForm.getApplicationFormId(),
+            applicationForm.getWantedSubject(),
+            applicationForm.getAge(),
+            applicationForm.getClassCount(),
+            applicationForm.getClassTime(),
+            (int) (applicationForm.getPay() * (5.0 / 6.0)),
+            applicationForm.getOnline(),
+            applicationForm.getDistrict().getDescription(),
+            applicationForm.getDong(),
+            goals,
+            applicationForm.getFavoriteStyle(),
+            dayTimes,
+            classMatching.getMatchStatus());
   }
 }

--- a/api/src/main/java/com/yedu/backend/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
+++ b/api/src/main/java/com/yedu/backend/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
@@ -1,28 +1,47 @@
 package com.yedu.backend.domain.matching.application.usecase;
 
-import static com.yedu.backend.domain.matching.application.mapper.ClassMatchingMapper.mapToApplicationFormToTeacherResponse;
-
 import com.yedu.backend.domain.matching.application.dto.res.ClassMatchingForTeacherResponse;
 import com.yedu.backend.domain.matching.domain.entity.ClassMatching;
 import com.yedu.backend.domain.matching.domain.service.ClassMatchingGetService;
 import com.yedu.backend.domain.parents.domain.entity.ApplicationForm;
+import com.yedu.backend.domain.parents.domain.entity.ApplicationFormAvailable;
 import com.yedu.backend.domain.parents.domain.entity.Goal;
+import com.yedu.backend.domain.parents.domain.service.ApplicationFormAvailableQueryService;
 import com.yedu.backend.domain.parents.domain.service.ParentsGetService;
-import java.util.List;
+import com.yedu.backend.domain.parents.domain.vo.DayTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.yedu.backend.domain.matching.application.mapper.ClassMatchingMapper.mapToApplicationFormToTeacherResponse;
+import static java.util.Comparator.comparing;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ClassMatchingInfoUseCase {
   private final ClassMatchingGetService classMatchingGetService;
+  private final ApplicationFormAvailableQueryService availableQueryService;
   private final ParentsGetService parentsGetService;
 
   public ClassMatchingForTeacherResponse applicationFormToTeacher(
       String applicationFormId, long teacherId, String phoneNumber) {
     ApplicationForm applicationForm = parentsGetService.applicationFormByFormId(applicationFormId);
+    List<DayTime> dayTimes = new ArrayList<>(availableQueryService.query(applicationFormId).stream()
+            .collect(Collectors.groupingBy(
+                    ApplicationFormAvailable::getDay,
+                    Collectors.mapping(ApplicationFormAvailable::getAvailableTime, Collectors.toList())
+            ))
+            .entrySet()
+            .stream()
+            .map(entry -> new DayTime(entry.getKey(), entry.getValue()))
+            .toList());
+    dayTimes.sort(comparing(dayTime -> dayTime.getDay().getDayNum()));
+
     List<String> goals =
         parentsGetService.goalsByApplicationForm(applicationForm).stream()
             .map(Goal::getClassGoal)
@@ -32,6 +51,6 @@ public class ClassMatchingInfoUseCase {
         classMatchingGetService.classMatchingByApplicationFormIdAndTeacherId(
             applicationFormId, teacherId, phoneNumber);
 
-    return mapToApplicationFormToTeacherResponse(classMatching, applicationForm, goals);
+    return mapToApplicationFormToTeacherResponse(classMatching, applicationForm, goals, dayTimes);
   }
 }

--- a/api/src/main/java/com/yedu/backend/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
+++ b/api/src/main/java/com/yedu/backend/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
@@ -1,5 +1,8 @@
 package com.yedu.backend.domain.matching.application.usecase;
 
+import static com.yedu.backend.domain.matching.application.mapper.ClassMatchingMapper.mapToApplicationFormToTeacherResponse;
+import static java.util.Comparator.comparing;
+
 import com.yedu.backend.domain.matching.application.dto.res.ClassMatchingForTeacherResponse;
 import com.yedu.backend.domain.matching.domain.entity.ClassMatching;
 import com.yedu.backend.domain.matching.domain.service.ClassMatchingGetService;
@@ -9,16 +12,12 @@ import com.yedu.backend.domain.parents.domain.entity.Goal;
 import com.yedu.backend.domain.parents.domain.service.ApplicationFormAvailableQueryService;
 import com.yedu.backend.domain.parents.domain.service.ParentsGetService;
 import com.yedu.backend.domain.parents.domain.vo.DayTime;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static com.yedu.backend.domain.matching.application.mapper.ClassMatchingMapper.mapToApplicationFormToTeacherResponse;
-import static java.util.Comparator.comparing;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/api/src/main/java/com/yedu/backend/domain/parents/application/dto/req/ApplicationFormRequest.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/application/dto/req/ApplicationFormRequest.java
@@ -18,6 +18,5 @@ public record ApplicationFormRequest(
     String classTime,
     String district,
     String dong,
-    String wantTime,
     String source,
     List<DayTime> dayTimes) {}

--- a/api/src/main/java/com/yedu/backend/domain/parents/application/mapper/ParentsMapper.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/application/mapper/ParentsMapper.java
@@ -37,7 +37,6 @@ public class ParentsMapper {
         .wantedSubject(request.wantedSubject())
         .favoriteStyle(request.favoriteStyle())
         .favoriteGender(request.favoriteGender())
-        .wantTime(request.wantTime())
         .classCount(request.classCount())
         .classTime(request.classTime())
         .source(request.source())

--- a/api/src/main/java/com/yedu/backend/domain/parents/domain/entity/ApplicationForm.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/domain/entity/ApplicationForm.java
@@ -61,7 +61,7 @@ public class ApplicationForm extends BaseEntity {
   private String favoriteDirection; // 수업 방향성
 
   @Column(nullable = false, columnDefinition = "TEXT")
-  private String wantTime; // 수업 날짜
+  private String wantTime; // 원하는 시간 없어짐
 
   @Column(nullable = false)
   private String classCount; // 몇회 (1,2,3)

--- a/api/src/main/java/com/yedu/backend/domain/parents/domain/vo/DayTime.java
+++ b/api/src/main/java/com/yedu/backend/domain/parents/domain/vo/DayTime.java
@@ -1,5 +1,6 @@
 package com.yedu.backend.domain.parents.domain.vo;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.yedu.backend.domain.teacher.domain.entity.constant.Day;
 import java.time.LocalTime;
 import java.util.List;
@@ -12,5 +13,6 @@ public class DayTime {
 
   private final Day day;
 
+  @JsonFormat(pattern = "HH:mm")
   private final List<LocalTime> times;
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약

선생님 과외 공지 API 응답 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

학부모 Tally 신청시 선호하는 시간 작성 삭제
-> Tally신청건 받는 request 에서 wantTime 삭제
-> 이에 따라 선생님이 확인하는 과외 공지에서 선호하는 시간 안내 수정 필요
기존의 String 타입의 wantTime -> List<DayTime> 의 dayTimes 변경

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

Tally 가 실제로 연결되고 다시 확인해봐야 할 것 같아요!
우선은 Tally에서 wantTime을 받는게 사라진 것으로 보여서 request 에서 wantTime은 삭제했습니다.

## ✅ 체크리스트
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?