### PR TITLE
feat : 알림톡 연동 마무리

### DIFF
--- a/api/src/main/java/com/yedu/backend/admin/application/usecase/AdminManageUseCase.java
+++ b/api/src/main/java/com/yedu/backend/admin/application/usecase/AdminManageUseCase.java
@@ -22,6 +22,7 @@ import com.yedu.backend.global.event.publisher.EventPublisher;
 import com.yedu.cache.support.dto.MatchingTimeTableDto;
 import com.yedu.cache.support.dto.TeacherNotifyApplicationFormDto;
 import com.yedu.cache.support.storage.KeyStorage;
+import com.yedu.cache.support.storage.MatchingIdApplicationNotifyKeyStorage;
 import com.yedu.cache.support.storage.ResponseRateStorage;
 import com.yedu.cache.support.storage.TeacherNotifyApplicationFormKeyStorage;
 import com.yedu.common.event.bizppurio.RecommendTeacherEvent;
@@ -45,6 +46,7 @@ public class AdminManageUseCase {
   private final EventPublisher eventPublisher;
   private final KeyStorage<MatchingTimeTableDto> matchingTimetableKeyStorage;
   private final TeacherNotifyApplicationFormKeyStorage teacherNotifyApplicationFormKeyStorage;
+  private final MatchingIdApplicationNotifyKeyStorage matchingIdApplicationNotifyKeyStorage;
 
   public void updateParentsKakaoName(long parentsId, ParentsKakaoNameRequest request) {
     Parents parents = adminGetService.parentsById(parentsId);
@@ -118,6 +120,7 @@ public class AdminManageUseCase {
         teacherNotifyApplicationFormKeyStorage.storeAndGet(
             new TeacherNotifyApplicationFormDto(
                 classMatching.getClassMatchingId(), applicationFormId));
+    matchingIdApplicationNotifyKeyStorage.store(classMatching.getClassMatchingId(), token);
 
     eventPublisher.publishNotifyClassInfoEvent(mapToNotifyClassInfoEvent(classMatching, token));
 

--- a/api/src/main/java/com/yedu/backend/admin/presentation/AdminTestController.java
+++ b/api/src/main/java/com/yedu/backend/admin/presentation/AdminTestController.java
@@ -36,6 +36,7 @@ import com.yedu.backend.domain.teacher.domain.service.TeacherGetService;
 import com.yedu.backend.domain.teacher.domain.service.TeacherSaveService;
 import com.yedu.backend.global.event.publisher.EventPublisher;
 import com.yedu.cache.support.dto.TeacherNotifyApplicationFormDto;
+import com.yedu.cache.support.storage.MatchingIdApplicationNotifyKeyStorage;
 import com.yedu.cache.support.storage.TeacherNotifyApplicationFormKeyStorage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -70,6 +71,7 @@ public class AdminTestController {
   private final ClassMatchingGetService classMatchingGetService;
   private final EventPublisher eventPublisher;
   private final TeacherNotifyApplicationFormKeyStorage teacherNotifyApplicationFormKeyStorage;
+  private final MatchingIdApplicationNotifyKeyStorage matchingIdApplicationNotifyKeyStorage;
 
   @PostMapping("/test/teacher/signup/{phoneNumber}")
   @Operation(summary = "선생님 간편 가입 - 전화번호를 넣어주세요 (간편가입이라 내용은 기대하지 마세요)")
@@ -196,8 +198,10 @@ public class AdminTestController {
           TeacherNotifyApplicationFormDto teacherNotifyApplicationFormDto =
               new TeacherNotifyApplicationFormDto(
                   classMatching.getClassMatchingId(), applicationFormId);
+
           String token =
               teacherNotifyApplicationFormKeyStorage.storeAndGet(teacherNotifyApplicationFormDto);
+          matchingIdApplicationNotifyKeyStorage.store(classMatching.getClassMatchingId(), token);
 
           eventPublisher.publishNotifyClassInfoEvent(
               mapToNotifyClassInfoEvent(classMatching, token));

--- a/api/src/main/java/com/yedu/backend/domain/teacher/application/usecase/TeacherBatchUseCase.java
+++ b/api/src/main/java/com/yedu/backend/domain/teacher/application/usecase/TeacherBatchUseCase.java
@@ -1,0 +1,34 @@
+package com.yedu.backend.domain.teacher.application.usecase;
+
+import com.yedu.backend.domain.teacher.domain.service.TeacherGetService;
+import com.yedu.backend.global.event.publisher.EventPublisher;
+import com.yedu.cache.support.storage.KeyStorage;
+import com.yedu.common.event.bizppurio.TeacherAvailableTimeUpdateRequestEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+@Slf4j
+public class TeacherBatchUseCase {
+
+  private final TeacherGetService teacherGetService;
+
+  private final EventPublisher eventPublisher;
+
+  private final KeyStorage<Long> updateAvailableTimeKeyStorage;
+
+  public void remindAvailableTime() {
+    teacherGetService.emptyAvailableTime().stream()
+        .map(
+            teacher ->
+                new TeacherAvailableTimeUpdateRequestEvent(
+                    teacher.getTeacherInfo().getNickName(),
+                    updateAvailableTimeKeyStorage.storeAndGet(teacher.getTeacherId()),
+                    teacher.getTeacherInfo().getPhoneNumber()))
+        .forEach(eventPublisher::publishTeacherAvailableTimeUpdateRequestEvent);
+  }
+}

--- a/api/src/main/java/com/yedu/backend/domain/teacher/domain/repository/TeacherDslRepository.java
+++ b/api/src/main/java/com/yedu/backend/domain/teacher/domain/repository/TeacherDslRepository.java
@@ -16,4 +16,6 @@ public interface TeacherDslRepository {
       List<ClassMatching> classMatchings, TeacherSearchRequest request);
 
   List<Teacher> getRemindTeacher();
+
+  List<Teacher> getEmptyAvailableTimeTeacher();
 }

--- a/api/src/main/java/com/yedu/backend/domain/teacher/domain/repository/TeacherDslRepositoryImpl.java
+++ b/api/src/main/java/com/yedu/backend/domain/teacher/domain/repository/TeacherDslRepositoryImpl.java
@@ -254,4 +254,14 @@ public class TeacherDslRepositoryImpl implements TeacherDslRepository {
             teacher.remind.isFalse())
         .fetch();
   }
+
+  @Override
+  public List<Teacher> getEmptyAvailableTimeTeacher() {
+    return queryFactory
+        .selectFrom(teacher)
+        .leftJoin(teacherAvailable)
+        .on(teacherAvailable.teacher.eq(teacher))
+        .where(teacher.status.eq(TeacherStatus.활동중), teacherAvailable.isNull())
+        .fetch();
+  }
 }

--- a/api/src/main/java/com/yedu/backend/domain/teacher/domain/service/TeacherGetService.java
+++ b/api/src/main/java/com/yedu/backend/domain/teacher/domain/service/TeacherGetService.java
@@ -92,4 +92,8 @@ public class TeacherGetService {
   public List<Teacher> remindTeachers() {
     return teacherRepository.getRemindTeacher();
   }
+
+  public List<Teacher> emptyAvailableTime() {
+    return teacherRepository.getEmptyAvailableTimeTeacher();
+  }
 }

--- a/api/src/main/java/com/yedu/backend/domain/teacher/presentation/TeacherBatchController.java
+++ b/api/src/main/java/com/yedu/backend/domain/teacher/presentation/TeacherBatchController.java
@@ -1,0 +1,27 @@
+package com.yedu.backend.domain.teacher.presentation;
+
+import com.yedu.backend.domain.teacher.application.usecase.TeacherBatchUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/teacher")
+@RequiredArgsConstructor
+@Tag(name = "TEACHER Controller")
+public class TeacherBatchController {
+
+  private final TeacherBatchUseCase teacherBatchUseCase;
+
+  @PostMapping("/sync/request/availability-time")
+  @Operation(summary = "선생님 가능 시간 갱신 요청 알림톡")
+  public ResponseEntity<Void> remindAvailableTime() {
+    teacherBatchUseCase.remindAvailableTime();
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/api/src/main/java/com/yedu/backend/global/event/mapper/BizppurioEventMapper.java
+++ b/api/src/main/java/com/yedu/backend/global/event/mapper/BizppurioEventMapper.java
@@ -12,6 +12,7 @@ import com.yedu.backend.domain.teacher.domain.entity.TeacherInfo;
 import com.yedu.common.event.bizppurio.*;
 import com.yedu.common.event.bizppurio.MatchingParentsEvent.ParentsClassNoticeEvent;
 import com.yedu.common.event.bizppurio.MatchingParentsEvent.ParentsExchangeEvent;
+import java.util.ArrayList;
 import java.util.List;
 
 public class BizppurioEventMapper {
@@ -140,21 +141,24 @@ public class BizppurioEventMapper {
   }
 
   public static TeacherExchangeEvent mapToTeacherExchangeEvent(
-      String key, ClassManagement classManagement) {
+      String classManagementToken, String classNotifyToken, ClassManagement classManagement) {
     ClassMatching classMatching = classManagement.getClassMatching();
     Teacher teacher = classMatching.getTeacher();
     ApplicationForm applicationForm = classMatching.getApplicationForm();
     Parents parents = applicationForm.getParents();
+
     return new TeacherExchangeEvent(
         applicationForm.getApplicationFormId(),
         applicationForm.getClassCount(),
         applicationForm.getClassTime(),
+        new ArrayList<>(),
         applicationForm.getAge(),
         applicationForm.getDistrict().getDescription(),
         applicationForm.getPay(),
         parents.getPhoneNumber(),
         teacher.getTeacherInfo().getPhoneNumber(),
-        key);
+        classNotifyToken,
+        classManagementToken);
   }
 
   public static MatchingParentsEvent mapToMatchingParentsEvent(ClassManagement classManagement) {

--- a/api/src/main/java/com/yedu/backend/global/event/publisher/EventPublisher.java
+++ b/api/src/main/java/com/yedu/backend/global/event/publisher/EventPublisher.java
@@ -83,4 +83,9 @@ public class EventPublisher {
   public void publishPayNotificationEvent(PayNotificationEvent event) {
     applicationEventPublisher.publishEvent(event);
   }
+
+  public void publishTeacherAvailableTimeUpdateRequestEvent(
+      TeacherAvailableTimeUpdateRequestEvent event) {
+    applicationEventPublisher.publishEvent(event);
+  }
 }

--- a/shared/bizppurio-support/src/main/java/com/yedu/bizppurio/support/application/mapper/BizppurioMapper.java
+++ b/shared/bizppurio-support/src/main/java/com/yedu/bizppurio/support/application/mapper/BizppurioMapper.java
@@ -9,6 +9,7 @@ import com.yedu.bizppurio.support.application.dto.req.ContentRequest;
 import com.yedu.bizppurio.support.application.dto.req.content.*;
 import com.yedu.common.event.bizppurio.*;
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.List;
@@ -84,8 +85,14 @@ public class BizppurioMapper {
   @Value("${bizppurio.yedu_offical_template.parents_class_info}")
   private String parentsClassInfo;
 
-  @Value("${bizppurio.yedu_offical_template.teacher_exchnage}")
-  private String teacherExchange;
+  @Value("${bizppurio.yedu_offical_template.teacher_class_notify_info}")
+  private String teacherClassNotifyInfo;
+
+  @Value("${bizppurio.yedu_offical_template.teacher_schedule}")
+  private String teacherSchedule;
+
+  @Value("${bizppurio.yedu_offical_template.teacher_setting}")
+  private String teacherSetting;
 
   @Value("${bizppurio.yedu_offical_template.teacher_class_remind}")
   private String teacherClassRemind;
@@ -231,7 +238,7 @@ public class BizppurioMapper {
               + "\n"
               + "\uD83E\uDD1E\uD83C\uDFFB신청 시, 철회는 불가합니다! 반드시 수업 시간과 장소를 확인 후 가능한 수업을 신청해주세요");
     }
-    String classUrl = "https://www.yedu-tutor.com/teacher/" + notifyClassInfoEvent.token();
+    String classUrl = "https://www.yedu-tutor.com/teacher/notify/" + notifyClassInfoEvent.token();
     CommonButton webButton = new WebButton("과외 정보 확인하기", WEB_LINK, classUrl, classUrl);
     Message messageBody =
         new ButtonMessage(message, yeduMatchingKey, notifyClass, new CommonButton[] {webButton});
@@ -393,18 +400,20 @@ public class BizppurioMapper {
   }
 
   public CommonRequest mapToRecommendTeacher(RecommendTeacherEvent recommendTeacherEvent) {
-    String title = "추천 : " + recommendTeacherEvent.teacherNickName() + " 선생님";
+    String title =
+        "추천 : #{name} 선생님".strip().replace("#{name}", recommendTeacherEvent.teacherNickName());
+
     String message =
         """
-            꼼꼼히 살펴보고 추천드려요
-            추천 : #{name} 선생님
-            신청해주신 #{district} 과외 매칭을 위한 선생님을 안내드립니다.
+꼼꼼히 살펴보고 추천드려요
+추천 : #{name} 선생님
+신청해주신 #{district} 과외 매칭을 위한 선생님을 안내드립니다.
 
-            ☀️#{name}☀️을 아이의 #{subject}을 책임지고 지도해줄 선생님으로 추천드려요!
+☀️#{name}☀️을 아이의 #{subject}을 책임지고 지도해줄 선생님으로 추천드려요!
 
-            Y-Edu가 상담 내용과 신청서를 꼼꼼히 살펴보고 추천드리는 선생님이에요. 😀
+Y-Edu가 상담 내용과 신청서를 꼼꼼히 살펴보고 추천드리는 선생님이에요. 😀
 
-            아래 버튼을 눌러 '상세프로필'을 천천히 살펴보시고 매칭 희망하시는 경우 버튼을 눌러 제출해주세요
+아래 버튼을 눌러 '상세프로필'을 천천히 살펴보시고 매칭 희망하시는 경우 버튼을 눌러 제출해주세요
          """
             .strip()
             .replace("#{name}", recommendTeacherEvent.teacherNickName())
@@ -538,50 +547,110 @@ public class BizppurioMapper {
     return createCommonRequest(messageBody, parentsClassInfoEvent.parentsPhoneNumber());
   }
 
-  public CommonRequest mapToTeacherExchangePhoneNumber(TeacherExchangeEvent teacherExchangeEvent) {
+  public CommonRequest mapToTeacherNotifyClassInfo(TeacherExchangeEvent teacherExchangeEvent) {
     String message =
-        ("\uD83C\uDF89 과외 매칭을 축하드립니다!\n"
-            + "\n"
-            + teacherExchangeEvent.applicationFormId()
-            + "\n"
-            + "✅ 수업 시수 : "
-            + teacherExchangeEvent.classCount()
-            + " "
-            + teacherExchangeEvent.time()
-            + "\n"
-            + "✅ 아이 나이 : "
-            + teacherExchangeEvent.age()
-            + "\n"
-            + "✅ 장소 : "
-            + teacherExchangeEvent.district()
-            + "\n"
-            + "\n"
-            + "학부모님 연락처 : "
-            + teacherExchangeEvent.parentsPhoneNumber()
-            + "\n"
-            + "\n"
-            + "아래 철차에 따라 학부모님께 연락 부탁드려요!\n"
-            + "\n"
-            + "1\uFE0F⃣ 바로 학부모님께 문자를 통해 선생님 소개 후, 전화상담 시간을 잡아주세요.\n"
-            + "\n"
-            + "2\uFE0F⃣ 24시간 내로 전화상담을 진행해주세요.\n"
-            + "전화 상담 시, 수업 방향성/ 수업 교재/ 첫수업일 / 정규 수업 요일, 일시 를 확정해주세요.\n"
-            + "\n"
-            + "3\uFE0F⃣ 전화상담 결과 공유\n"
-            + "전화 상담 내용을 기록하는 링크를 미리 보내드릴게요.\n"
-            + "전화 상담 후, 링크로 들어가 상담 결과를 작성 후 제출해주세요. \uD83D\uDE4F\n"
-            + "\n"
-            + "☝\uD83C\uDFFB상담 결과 공유가 완료되지 않으면 보수 지급이 지연될 수 있습니다!");
+        """
+🎉 과외 매칭 성사를 축하드립니다!
+
+#{applicationFormId}
+✅ 수업 시수 : 주 #{count}회 #{time}분
+✅ 정규 수업 요일, 일시
+#{dayTimes}
+✅ 아이 나이 : #{age}
+✅ 장소 : #{district}
+✅ 보수 : #{pay}원
+
+자세한 수업 정보는
+아래의 버튼을 눌러 확인해주세요
+       """
+            .strip()
+            .replace("#{applicationFormId}", teacherExchangeEvent.applicationFormId())
+            .replace("#{count}", teacherExchangeEvent.classCount())
+            .replace("#{time}", teacherExchangeEvent.time())
+            .replace(
+                "#{dayTimes}",
+                teacherExchangeEvent.dayTimes().stream()
+                    .map(
+                        dayTime ->
+                            dayTime.day()
+                                + " "
+                                + dayTime.times().stream()
+                                    .map(LocalTime::toString)
+                                    .collect(Collectors.joining(", ")))
+                    .collect(Collectors.joining("\n"))
+                    .replace("#{age}", teacherExchangeEvent.age())
+                    .replace("#{district}", teacherExchangeEvent.district())
+                    .replace("#{pay}", String.valueOf(teacherExchangeEvent.money())));
+
     CommonButton webButton =
         new WebButton(
-            "전화상담 결과 공유하기",
+            "수업 정보 확인",
             WEB_LINK,
-            resultShareFormUrl + teacherExchangeEvent.managementId(),
-            resultShareFormUrl + teacherExchangeEvent.managementId());
+            "https://www.yedu-tutor.com/teacher/match-success/"
+                + teacherExchangeEvent.classNotifyToken(),
+            "https://www.yedu-tutor.com/teacher/match-success/"
+                + teacherExchangeEvent.classNotifyToken());
     Message messageBody =
         new ButtonMessage(
-            message, yeduMatchingKey, teacherExchange, new CommonButton[] {webButton});
+            message, yeduMatchingKey, teacherClassNotifyInfo, new CommonButton[] {webButton});
     return createCommonRequest(messageBody, teacherExchangeEvent.teacherPhoneNumber());
+  }
+
+  public CommonRequest mapToTeacherSchedule(TeacherExchangeEvent teacherExchangeEvent) {
+    String message =
+        """
+📌 학부모님 연락처 : #{phoneNumer}
+바로 학부모님께 문자를 통해 선생님을소개한 후, 전화상담 시간을 잡아주세요
+
+📌 24시간 내로 전화상담을 진행하며아래 내용을 확정해주세요
+🌟 수업 방향성
+🌟 수업 교재
+🌟 첫 수업 날짜
+🌟 정규 수업 요일, 일시
+🌟 교재명
+
+📌 전화 후 반드시!
+아래 버튼을 눌러 확정된 상담 결과를전달해주세요
+       """
+            .strip()
+            .replace("#{phoneNumer}", teacherExchangeEvent.parentsPhoneNumber());
+
+    CommonButton webButton =
+        new WebButton(
+            "수업 정보 확인",
+            WEB_LINK,
+            "https://yedu-tutor.com/result/" + teacherExchangeEvent.classManagementToken(),
+            "https://xyedu-tutor.com/result/" + teacherExchangeEvent.classManagementToken());
+    Message messageBody =
+        new ButtonMessage(
+            message, yeduMatchingKey, teacherSchedule, new CommonButton[] {webButton});
+    return createCommonRequest(messageBody, teacherExchangeEvent.teacherPhoneNumber());
+  }
+
+  public CommonRequest mapToTeacherAvailableTimeUpdateRequest(
+      TeacherAvailableTimeUpdateRequestEvent event) {
+    String message =
+        """
+📣 #{닉네임} 선생님, 수업 가능시간을 알려주세요.
+
+앞으로 Y-Edu에서 수업 가능 시간을 고려하여 과외 공지를 전달드리려 해요.
+
+이전 활동성 조사에 답변 주셨던 분들을 대상으로, 수업 가능 시간 설정을 요청드리고 있습니다.
+
+미 설정 시, 과외 공지 전달에 지장이 있을 수 있으니, 꼭 빠르게 아래 링크로 설정해 주세요 🙂
+       """
+            .strip()
+            .replace("#{닉네임}", event.name());
+
+    CommonButton webButton =
+        new WebButton(
+            "수업 가능시간 설정하기",
+            WEB_LINK,
+            "https://yedu-tutor.com/teachersetting/time?token=" + event.token(),
+            "https://yedu-tutor.com/teachersetting/time?token=" + event.token());
+    Message messageBody =
+        new ButtonMessage(message, yeduOfficialKey, teacherSetting, new CommonButton[] {webButton});
+    return createCommonRequest(messageBody, event.teacherPhoneNumber());
   }
 
   public CommonRequest mapToTeacherClassRemind(TeacherClassRemindEvent teacherClassRemindEvent) {

--- a/shared/bizppurio-support/src/main/java/com/yedu/bizppurio/support/event/listener/BizppurioTeacherMessageListener.java
+++ b/shared/bizppurio-support/src/main/java/com/yedu/bizppurio/support/event/listener/BizppurioTeacherMessageListener.java
@@ -84,4 +84,11 @@ public class BizppurioTeacherMessageListener {
   public void handleMatchingConfirmTeacher(MatchingConfirmTeacherEvent event) {
     bizppurioTeacherMessage.matchingConfirmTeacher(event);
   }
+
+  @EventListener
+  @Async
+  public void handleTeacherAvailableTimeUpdateRequest(
+      TeacherAvailableTimeUpdateRequestEvent event) {
+    bizppurioTeacherMessage.teacherAvailableTimeUpdateRequest(event);
+  }
 }

--- a/shared/cache-support/src/main/java/com/yedu/cache/support/storage/MatchingIdApplicationNotifyKeyStorage.java
+++ b/shared/cache-support/src/main/java/com/yedu/cache/support/storage/MatchingIdApplicationNotifyKeyStorage.java
@@ -1,0 +1,33 @@
+package com.yedu.cache.support.storage;
+
+import com.yedu.cache.support.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/***
+ * 과외 공지 발송시 사용한 토큰 정보 저장소
+ * key : matchingId
+ * value : teacherNotifyApplicationFormKeyStorage token
+ */
+@Component
+@RequiredArgsConstructor
+public class MatchingIdApplicationNotifyKeyStorage implements TokenStorage<Long> {
+
+  private static final String KEY = "matching-teacher-notify:%s";
+
+  private final RedisRepository redisRepository;
+
+  @Override
+  public void store(Long matchingId, String token) {
+    redisRepository.setValue(buildKey(matchingId), token);
+  }
+
+  @Override
+  public String get(Long matchingId) {
+    return redisRepository.getValues(buildKey(matchingId)).orElse(null);
+  }
+
+  private String buildKey(Long matchingId) {
+    return KEY.formatted(matchingId);
+  }
+}

--- a/shared/cache-support/src/main/java/com/yedu/cache/support/storage/TokenStorage.java
+++ b/shared/cache-support/src/main/java/com/yedu/cache/support/storage/TokenStorage.java
@@ -1,0 +1,8 @@
+package com.yedu.cache.support.storage;
+
+public interface TokenStorage<T> {
+
+  void store(T id, String token);
+
+  String get(T id);
+}

--- a/shared/cache-support/src/main/java/com/yedu/cache/support/storage/UpdateAvailableTimeKeyStorage.java
+++ b/shared/cache-support/src/main/java/com/yedu/cache/support/storage/UpdateAvailableTimeKeyStorage.java
@@ -1,0 +1,16 @@
+package com.yedu.cache.support.storage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yedu.cache.support.RedisRepository;
+import java.time.Duration;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdateAvailableTimeKeyStorage extends AbstractKeyStorage<Long> {
+
+  public UpdateAvailableTimeKeyStorage(RedisRepository redisRepository, ObjectMapper objectMapper) {
+    super(
+        "teacher-available-time:%s",
+        Duration.ofDays(30), redisRepository, objectMapper, Long.class);
+  }
+}

--- a/shared/common/src/main/java/com/yedu/common/event/bizppurio/TeacherAvailableTimeUpdateRequestEvent.java
+++ b/shared/common/src/main/java/com/yedu/common/event/bizppurio/TeacherAvailableTimeUpdateRequestEvent.java
@@ -1,0 +1,4 @@
+package com.yedu.common.event.bizppurio;
+
+public record TeacherAvailableTimeUpdateRequestEvent(
+    String name, String token, String teacherPhoneNumber) {}

--- a/shared/common/src/main/java/com/yedu/common/event/bizppurio/TeacherExchangeEvent.java
+++ b/shared/common/src/main/java/com/yedu/common/event/bizppurio/TeacherExchangeEvent.java
@@ -1,12 +1,20 @@
 package com.yedu.common.event.bizppurio;
 
+import java.time.LocalTime;
+import java.util.List;
+
 public record TeacherExchangeEvent(
     String applicationFormId,
     String classCount,
     String time,
+    List<DayTime> dayTimes,
     String age,
     String district,
     int money,
     String parentsPhoneNumber,
     String teacherPhoneNumber,
-    String managementId) {}
+    String classNotifyToken,
+    String classManagementToken) {
+
+  public record DayTime(String day, List<LocalTime> times) {}
+}

--- a/shared/discord-support/src/main/java/com/yedu/discord/support/DiscordWebhookUseCase.java
+++ b/shared/discord-support/src/main/java/com/yedu/discord/support/DiscordWebhookUseCase.java
@@ -4,6 +4,7 @@ import static com.yedu.discord.support.DiscordMapper.*;
 
 import com.yedu.common.event.bizppurio.NotifyClassInfoEvent;
 import com.yedu.common.event.bizppurio.RecommendTeacherEvent;
+import com.yedu.common.event.bizppurio.TeacherExchangeEvent;
 import com.yedu.common.event.discord.*;
 import com.yedu.discord.support.dto.req.DiscordWebhookRequest;
 import com.yedu.discord.support.dto.req.DiscordWebhookRequest.Field;
@@ -143,6 +144,26 @@ public class DiscordWebhookUseCase {
                     + "\n"));
 
     DiscordWebhookRequest request = mapToDiscordWithInformation("선생님 추천 알림톡 발송 완료", fields);
+    webhookClient.sendWebhook(DiscordWebhookType.NOTIFY_APPLICATION_FORM_TO_TEACHER, request);
+  }
+
+  public void sendTeacherExchangeEvent(TeacherExchangeEvent event) {
+    List<Field> fields =
+        List.of(
+            mapToField(
+                "발송 정보",
+                "- applicationFormId : "
+                    + event.applicationFormId()
+                    + "- 선생님 핸드폰번호 : "
+                    + event.teacherPhoneNumber()
+                    + "\n"
+                    + "- 수업 정보 확인 token: \n"
+                    + event.classNotifyToken()
+                    + "- 상담 결과 저장하기 token: \n"
+                    + event.classManagementToken()
+                    + "\n"));
+
+    DiscordWebhookRequest request = mapToDiscordWithInformation("선생님 매칭 완료 알림톡 발송 완료", fields);
     webhookClient.sendWebhook(DiscordWebhookType.NOTIFY_APPLICATION_FORM_TO_TEACHER, request);
   }
 }

--- a/shared/discord-support/src/main/java/com/yedu/discord/support/listener/DiscordEventListener.java
+++ b/shared/discord-support/src/main/java/com/yedu/discord/support/listener/DiscordEventListener.java
@@ -2,6 +2,7 @@ package com.yedu.discord.support.listener;
 
 import com.yedu.common.event.bizppurio.NotifyClassInfoEvent;
 import com.yedu.common.event.bizppurio.RecommendTeacherEvent;
+import com.yedu.common.event.bizppurio.TeacherExchangeEvent;
 import com.yedu.common.event.discord.*;
 import com.yedu.discord.support.DiscordWebhookUseCase;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +45,12 @@ public class DiscordEventListener {
   @Async
   public void handleRecommendTeacherEvent(RecommendTeacherEvent event) {
     discordWebhookUseCase.sendRecommendTeacherEvent(event);
+  }
+
+  @EventListener
+  @Async
+  public void handleScheduleEvent(TeacherExchangeEvent event) {
+    discordWebhookUseCase.sendTeacherExchangeEvent(event);
   }
 
   @EventListener


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/list-e0e0be947a564f3794bc46f988352c73?p=1dbafa1037b280cb885beed78703ba40&pm=s

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 선생님 가능시간 리마인드 알림톡 API 개발

- 1. 선생님 가능 시간 알림톡 / 2. 요청 매칭 성사 알림톡  / 3. 상담 요청 알림톡  연동

- 선생님 추천 알림톡은 오타인지 연동이 안되고있어서 줄바꿈 제거해보았습니다!

- 매칭 성공 이후에 과외 공지 알림톡에 발급되는 토큰으로 과외 정보를 볼수 있어야해서, 
matching를 key로 과외 공지 알림톡 토큰을 조회할수있도록 수정했습니다


## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- application.yaml 파일 노션에 수정하였습니다! (template_key추가)

- 토큰이 세어보니까 4개더라구요, 근데 또 토큰별로 사용하는 API가 다르다보니 한번 이번스프린트 끝나고 코드정리를 하긴해야댈것같아여 

1. 과외공지 알림 토큰
2. 선생님 추천 토큰
3. 선생님 가능시간 업데이트 토큰
4. 매칭 후반부 자동화에서 사용한  classManagement 토큰 

## ✅ 체크리스트
- [v] Label 지정했나요?
- [v] 관련 테크스펙 링크 연결했나요?