### PR TITLE
과외 일시중지시 과외 수업 일정 노출 조건 수정

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
@@ -29,6 +29,7 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules) {
       @Schema(description = "숙제") String homework,
       @Schema(description = "과외 일시") LocalDate classDate,
       @Schema(description = "과외 시간") LocalTime classStart,
+      @Schema(description = "회차 정보") Integer round,
       @Schema(description = "과외 소요시간") Integer classMinute) {}
 
   public static Page<SessionResponse.Schedule> from(Page<ClassSession> sessions) {
@@ -43,6 +44,7 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules) {
                 .classStart(it.getClassTime().getStart())
                 .understanding(it.getUnderstanding())
                 .homework(it.getHomework())
+                .round(it.getRound())
                 .classMinute(it.getClassTime().getClassMinute())
                 .build());
   }

--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
@@ -2,6 +2,7 @@ package com.yedu.api.domain.matching.application.dto.res;
 
 import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -10,7 +11,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
 
-public record SessionResponse(Map<String, ScheduleInfo> schedules) {
+public record SessionResponse(Map<String, ScheduleInfo> schedules, Map<String, MatchingStatus> matchingStatuses) {
 
   public record ScheduleInfo(
       Page<Schedule> schedules,
@@ -50,6 +51,6 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules) {
   }
 
   public static SessionResponse empty() {
-    return new SessionResponse(Map.of());
+    return new SessionResponse(Map.of(), Map.of());
   }
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
@@ -50,6 +50,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -261,7 +262,13 @@ public class ClassScheduleMatchingUseCase {
     List<ClassMatching> matchings =
         classSessionCommandService.createSessionOf(teacher, false, null);
 
-    return classSessionQueryService.query(matching, matchings, isComplete, pageable);
+    List<ClassMatching> pausedMatching = classMatchingGetService.getPaused(teacher);
+
+    List<ClassMatching> merged = Stream.of(matchings, pausedMatching)
+        .flatMap(List::stream)
+        .toList();
+
+    return classSessionQueryService.query(matching, merged, isComplete, pageable);
   }
 
   public void changeSessionDate(Long sessionId, ChangeSessionDateRequest request) {

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassMatchingRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassMatchingRepository.java
@@ -5,6 +5,7 @@ import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import com.yedu.api.domain.parents.domain.entity.ApplicationForm;
 import com.yedu.api.domain.teacher.domain.entity.Teacher;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Sort;
@@ -39,4 +40,6 @@ public interface ClassMatchingRepository
   void deleteAllByApplicationForm_Parents_PhoneNumber(String phoneNumber);
 
   void deleteAllByTeacher_TeacherInfo_PhoneNumber(String phoneNumber);
+
+  List<ClassMatching> findByTeacherAndMatchStatusIn(Teacher teacher, Collection<MatchingStatus> matchStatuses);
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepositoryImpl.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepositoryImpl.java
@@ -106,8 +106,10 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
 
     return predicate.and(
         classSession.classManagement.classMatching.matchStatus.ne(MatchingStatus.일시중단)
+            .and(classSession.classManagement.classMatching.matchStatus.ne(MatchingStatus.중단))
             .or(
-                classSession.classManagement.classMatching.matchStatus.eq(MatchingStatus.일시중단)
+                (classSession.classManagement.classMatching.matchStatus.eq(MatchingStatus.일시중단)
+                    .or(classSession.classManagement.classMatching.matchStatus.eq(MatchingStatus.중단)))
                     .and(
                         classSession.sessionDate.loe(
                             Expressions.dateTemplate(
@@ -117,7 +119,8 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
                             )
                         )
                     )
-            ));
+            )
+    );
   }
 
 

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepositoryImpl.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepositoryImpl.java
@@ -4,10 +4,14 @@ import static com.yedu.api.domain.matching.domain.entity.QClassSession.classSess
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
 import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,27 +30,11 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
   @Override
   public Page<ClassSession> findByClassManagementAndSessionDateBetween(
       ClassManagement classManagement, LocalDate startDate, LocalDate endDate, Pageable pageable) {
-
     LocalDate now = LocalDate.now();
     List<ClassSession> results =
         queryFactory
             .selectFrom(classSession)
-            .where(
-                classSession.classManagement.eq(classManagement),
-                (classSession
-                        .sessionDate
-                        .after(now)
-                        .and(classSession.sessionDate.between(startDate, endDate)))
-                    .or(
-                        classSession
-                            .sessionDate
-                            .loe(now)
-                            .and(classSession.sessionDate.between(startDate, endDate))
-                            .and(classSession.cancel.isFalse()))
-                    .or(
-                        classSession.sessionDate.between(now.minusDays(7), endDate)
-                    )
-            )
+            .where(searchCondition(classManagement, null, now, startDate, endDate))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .orderBy(getOrderSpecifiers(pageable.getSort()))
@@ -56,23 +44,7 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
         queryFactory
             .select(classSession.count())
             .from(classSession)
-            .where(
-                classSession.classManagement.eq(classManagement),
-                (classSession
-                        .sessionDate
-                        .after(now)
-                        .and(classSession.sessionDate.between(startDate, endDate)))
-                    .or(
-                        classSession
-                            .sessionDate
-                            .loe(now)
-                            .and(classSession.sessionDate.between(startDate, endDate))
-                            .and(classSession.cancel.isFalse()))
-                    .or(
-                        classSession.sessionDate.between(now.minusDays(7), endDate)
-                    )
-            )
-
+            .where(searchCondition(classManagement, null, now, startDate, endDate))
             .fetchOne();
 
     return new PageImpl<>(results, pageable, total != null ? total : 0);
@@ -89,24 +61,7 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
     List<ClassSession> results =
         queryFactory
             .selectFrom(classSession)
-            .where(
-                classSession.classManagement.eq(classManagement),
-                classSession.completed.eq(completed),
-                (classSession
-                        .sessionDate
-                        .goe(now)
-                        .and(classSession.sessionDate.between(startDate, endDate)))
-                    .or(
-                        classSession
-                            .sessionDate
-                            .before(now)
-                            .and(classSession.sessionDate.between(startDate, endDate))
-                            .and(classSession.cancel.isFalse())
-                    )
-                    .or(
-                        classSession.sessionDate.between(now.minusDays(7), endDate)
-                    )
-            )
+            .where(searchCondition(classManagement, completed, now, startDate, endDate))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .orderBy(getOrderSpecifiers(pageable.getSort()))
@@ -116,29 +71,55 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
         queryFactory
             .select(classSession.count())
             .from(classSession)
-            .where(
-                classSession.classManagement.eq(classManagement),
-                classSession.completed.eq(completed),
-                (classSession
-                        .sessionDate
-                        .goe(now)
-                        .and(classSession.sessionDate.between(startDate, endDate)))
-                    .or(
-                        classSession
-                            .sessionDate
-                            .before(now)
-                            .and(classSession.sessionDate.between(startDate, endDate))
-                            .and(classSession.cancel.isFalse()))
-
-                    .or(
-                        classSession.sessionDate.between(now.minusDays(7), endDate)
-                    )
-
-            )
+            .where(searchCondition(classManagement, completed, now, startDate, endDate))
             .fetchOne();
 
     return new PageImpl<>(results, pageable, total != null ? total : 0);
   }
+
+
+  private Predicate searchCondition(
+      ClassManagement classManagement,
+      Boolean completed,
+      LocalDate now,
+      LocalDate startDate,
+      LocalDate endDate
+  ) {
+    BooleanExpression predicate = classSession.classManagement.eq(classManagement)
+        .and(classSession.completed.eq(completed))
+        .and(
+            classSession.sessionDate.goe(now)
+                .and(classSession.sessionDate.between(startDate, endDate))
+                .or(
+                    classSession.sessionDate.before(now)
+                        .and(classSession.sessionDate.between(startDate, endDate))
+                        .and(classSession.cancel.isFalse())
+                )
+                .or(
+                    classSession.sessionDate.between(now.minusDays(7), endDate)
+                )
+        );
+
+    if (completed == null) {
+      return predicate;
+    }
+
+    return predicate.and(
+        classSession.classManagement.classMatching.matchStatus.ne(MatchingStatus.일시중단)
+            .or(
+                classSession.classManagement.classMatching.matchStatus.eq(MatchingStatus.일시중단)
+                    .and(
+                        classSession.sessionDate.loe(
+                            Expressions.dateTemplate(
+                                LocalDate.class,
+                                "date({0})",
+                                classSession.classManagement.classMatching.pausedAt
+                            )
+                        )
+                    )
+            ));
+  }
+
 
   private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
     PathBuilder<ClassSession> pathBuilder = new PathBuilder<>(ClassSession.class, "classSession");

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassMatchingGetService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassMatchingGetService.java
@@ -39,7 +39,7 @@ public class ClassMatchingGetService {
   }
 
   public List<ClassMatching> getPaused(Teacher teacher) {
-    return classMatchingRepository.findByTeacherAndMatchStatus(teacher, MatchingStatus.일시중단);
+    return classMatchingRepository.findByTeacherAndMatchStatusIn(teacher, List.of(MatchingStatus.일시중단, MatchingStatus.중단));
   }
 
   public ClassMatching getBySessionId(Long sessionId) {

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassMatchingGetService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassMatchingGetService.java
@@ -38,6 +38,10 @@ public class ClassMatchingGetService {
     return classMatchingRepository.findByTeacherAndMatchStatus(teacher, MatchingStatus.최종매칭);
   }
 
+  public List<ClassMatching> getPaused(Teacher teacher) {
+    return classMatchingRepository.findByTeacherAndMatchStatus(teacher, MatchingStatus.일시중단);
+  }
+
   public ClassMatching getBySessionId(Long sessionId) {
     return classMatchingRepository
         .findBySessionId(sessionId)

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
@@ -96,7 +96,7 @@ public class ClassSessionCommandService {
 
           session.complete(request.classMinute(), request.understanding(), request.homework(), newRound);
         },
-        ()-> session.complete(request.classMinute(), request.understanding(), request.homework()));
+        ()-> session.complete(request.classMinute(), request.understanding(), request.homework(), 1));
 
 
     Hibernate.initialize(

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionQueryService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionQueryService.java
@@ -7,11 +7,13 @@ import com.yedu.api.domain.matching.application.dto.res.SessionResponse.Schedule
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
 import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import com.yedu.api.domain.matching.domain.repository.ClassSessionRepository;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -71,7 +73,14 @@ public class ClassSessionQueryService {
             .filter(Objects::nonNull)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    return new SessionResponse(scheduleMap);
+    Map<String, MatchingStatus> matchingStatusesMap = classMatchings.stream()
+        .map(matching -> {
+          String applicationFormId = matching.getApplicationForm().getApplicationFormId();
+          return Map.entry(applicationFormId, matching.getMatchStatus());
+        })
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    return new SessionResponse(scheduleMap, matchingStatusesMap);
   }
 
   public RetrieveSessionDateResponse querySessionDate(Long sessionId) {


### PR DESCRIPTION
- 과외 일시중지시 과외 수업 일정 노출 조건 수정
- 이전회차가 없을 경우 최초 회차는 1로 자동 설정되도록 수정

- 회차정보 API응답에 추가 
- 과외 상태 API 응답에 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session details now display additional round information for each schedule.
  * Teachers can now view sessions related to both active and paused matchings.
  * Matching statuses are now visible alongside session schedules for better tracking.

* **Refactor**
  * Improved internal logic for filtering and retrieving class sessions, resulting in more accurate session data.

* **Bug Fixes**
  * Ensured consistent handling of session completion, especially when previous session data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->