### PR TITLE
Feat: 당일휴강 처리 관련 필드 추가

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
@@ -24,6 +24,7 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules, Map<String, M
   public record Schedule(
       Long classSessionId,
       @Schema(description = "휴강 여부") boolean cancel,
+      @Schema(description = "당일 휴강 여부") boolean isTodayCancel,
       @Schema(description = "휴강 사유") String cancelReason,
       @Schema(description = "완료 여부") boolean complete,
       @Schema(description = "이해도") String understanding,
@@ -40,6 +41,7 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules, Map<String, M
             Schedule.builder()
                 .classSessionId(it.getClassSessionId())
                 .cancel(it.isCancel())
+                .isTodayCancel(it.isTodayCancel())
                 .cancelReason(it.getCancelReason())
                 .complete(it.isCompleted())
                 .classDate(it.getSessionDate())

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
@@ -15,6 +15,7 @@ import com.yedu.api.domain.matching.application.dto.res.ClassScheduleRetrieveRes
 import com.yedu.api.domain.matching.application.dto.res.RetrieveScheduleResponse;
 import com.yedu.api.domain.matching.application.dto.res.RetrieveSessionDateResponse;
 import com.yedu.api.domain.matching.application.dto.res.SessionResponse;
+import com.yedu.api.domain.matching.domain.entity.constant.CancelReason;
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
 import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.ClassSchedule;
@@ -296,7 +297,7 @@ public class ClassScheduleMatchingUseCase {
     );
   }
 
-  public void cancelSession(Long sessionId, String cancelReason) {
+  public void cancelSession(Long sessionId, CancelReason cancelReason) {
     ClassSession session = classSessionCommandService.cancel(sessionId, cancelReason);
     ClassManagement classManagement = session.getClassManagement();
     ClassMatching matching = classManagement.getClassMatching();

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
@@ -1,6 +1,7 @@
 package com.yedu.api.domain.matching.domain.entity;
 
 import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
+import com.yedu.api.domain.matching.domain.entity.constant.CancelReason;
 import com.yedu.api.domain.matching.domain.vo.ClassTime;
 import com.yedu.api.global.entity.BaseEntity;
 import jakarta.persistence.Embedded;
@@ -56,6 +57,8 @@ public class ClassSession extends BaseEntity {
 
   private Integer round; // 회차
 
+  private boolean isTodayCancel;
+
   public void cancel(String cancelReason) {
     if (cancel) {
       throw new IllegalStateException("이미 취소된 일정입니다");
@@ -76,6 +79,7 @@ public class ClassSession extends BaseEntity {
     }
 
     cancel = true;
+    isTodayCancel = sessionDate.isEqual(LocalDate.now());
     this.cancelReason = cancelReason;
   }
 

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/entity/constant/CancelReason.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/entity/constant/CancelReason.java
@@ -1,0 +1,7 @@
+package com.yedu.api.domain.matching.domain.entity.constant;
+
+public enum CancelReason {
+    TOGETHER,
+    PARENT,
+    TEACHER;
+}

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
@@ -1,6 +1,7 @@
 package com.yedu.api.domain.matching.domain.service;
 
 import com.yedu.api.domain.matching.application.dto.req.CompleteSessionRequest;
+import com.yedu.api.domain.matching.domain.entity.constant.CancelReason;
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
 import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.ClassSchedule;
@@ -60,10 +61,10 @@ public class ClassSessionCommandService {
         .toList();
   }
 
-  public ClassSession cancel(Long sessionId, String cancelReason) {
+  public ClassSession cancel(Long sessionId, CancelReason cancelReason) {
     ClassSession session = findSessionById(sessionId);
 
-    session.cancel(cancelReason);
+    session.cancel(cancelReason.name());
 
     return session;
   }

--- a/api/src/main/java/com/yedu/api/domain/matching/presentation/ClassMatchingScheduleController.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/presentation/ClassMatchingScheduleController.java
@@ -14,6 +14,7 @@ import com.yedu.api.domain.matching.application.dto.res.RetrieveScheduleResponse
 import com.yedu.api.domain.matching.application.dto.res.RetrieveSessionDateResponse;
 import com.yedu.api.domain.matching.application.dto.res.SessionResponse;
 import com.yedu.api.domain.matching.application.usecase.ClassScheduleMatchingUseCase;
+import com.yedu.api.domain.matching.domain.entity.constant.CancelReason;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -131,7 +132,7 @@ public class ClassMatchingScheduleController {
       description = "sessionId로 과외를 휴강 처리합니다",
       tags = {"완료톡 관련 API"})
   public ResponseEntity<Void> cancelSession(
-      @PathVariable Long sessionId, @RequestParam String cancelReason) {
+      @PathVariable Long sessionId, @RequestParam CancelReason cancelReason) {
 
     scheduleMatchingUseCase.cancelSession(sessionId, cancelReason);
 

--- a/api/src/main/resources/db/migration/V5_202505101604__create_class_session_table.sql
+++ b/api/src/main/resources/db/migration/V5_202505101604__create_class_session_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE class_session
     homework_percentage INT COMMENT '아이의 숙제 완료도(%)',
     cancel BOOLEAN DEFAULT FALSE COMMENT '휴강 여부',
     cancel_reason VARCHAR(255) COMMENT '휴강 사유',
+    is_today_cancel BOOLEAN DEFAULT FALSE COMMENT '당일 취소 여부',
     completed BOOLEAN DEFAULT FALSE COMMENT '수업 완료 여부',
     start TIME COMMENT '수업 시작 시간',
     class_minute INT COMMENT '수업 시간',


### PR DESCRIPTION
## 🐈 PR 요약
- 과외 상세 일정 보회 API: Response 필드 2건 추가/변경
- 휴강 처리 API: 당일 휴강 관련 로직 추가
- 관련 테크스펙 링크 : https://www.notion.so/flow-API-1efafa1037b280029bb7da91d4323442?source=copy_link

## ✨ PR 상세
1. `API 변경 - POST /sessions`
    - **isTodayCancel** - ****오늘날짜와 `session_date` 동일 여부 조건에 따른 값 삽입
    - **cancelReason** - 타입 enum 변경

2. class_session 테이블
-  isTodayCancel boolean 컬럼 추가

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## ✅ 체크리스트
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new indicator showing whether a session was canceled on the current day.
  * Introduced categorized cancellation reasons for sessions, allowing users to specify the reason for cancellation.

* **Bug Fixes**
  * Improved accuracy in tracking and displaying same-day cancellations.

* **Chores**
  * Updated system to use standardized cancellation reasons for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->