### PR TITLE
feat : graphql에 회차정보 추가

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/ApplicationFormResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/ApplicationFormResponse.java
@@ -110,5 +110,7 @@ public class ApplicationFormResponse {
     private Boolean cancel;
     private String cancelReason;
     private Boolean completed;
+    private Integer currentRound;
+    private Integer maxRound;
   }
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
@@ -220,6 +220,9 @@ public class ClassMatchingInfoUseCase {
     Optional<ClassManagement> management =
         classManagementQueryService.queryWithSchedule(applicationFormResponse.getMatchingId());
 
+    Integer maxRoundNumber = management.map(it -> it.getClassMatching().getApplicationForm().maxRoundNumber())
+        .orElse(null);
+
     return ApplicationFormResponse.ClassManagement.builder()
         .classManagementId(management.map(ClassManagement::getClassManagementId).orElse(null))
         .textBook(management.map(ClassManagement::getTextbook).orElse(null))
@@ -259,6 +262,8 @@ public class ClassMatchingInfoUseCase {
                                         .cancel(it.isCancel())
                                         .cancelReason(it.getCancelReason())
                                         .completed(it.isCompleted())
+                                        .currentRound(it.getRound())
+                                        .maxRound(maxRoundNumber)
                                         .build())
                             .toList())
                 .orElse(null))

--- a/api/src/main/resources/graphql/schema.graphqls
+++ b/api/src/main/resources/graphql/schema.graphqls
@@ -97,6 +97,8 @@ type Schedule {
 type Session {
     classSessionId: Int
     date: String
+    currentRound: Int
+    maxRound: Int
     start: String
     classMinute: Int
     understanding: String


### PR DESCRIPTION
graphql 스키마에 현재회차, 최대회차 정보 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new fields, `currentRound` and `maxRound`, to session-related responses and the GraphQL schema, providing additional session round information to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->