### PR TITLE
feat : 선생님 화면 > 월별 수업진행시간 집계 API 추가

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/RetrieveMonthlyClassTimeResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/RetrieveMonthlyClassTimeResponse.java
@@ -1,0 +1,19 @@
+package com.yedu.api.domain.matching.application.dto.res;
+
+import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+public record RetrieveMonthlyClassTimeResponse(Map<Integer, Integer> months) {
+
+}

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
@@ -2,10 +2,12 @@ package com.yedu.api.domain.matching.domain.repository;
 
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
 import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -28,4 +30,15 @@ public interface ClassSessionRepository
   Optional<ClassSession> findFirstByClassManagementAndSessionDateBeforeAndCompletedTrueAndCancelFalseAndRoundIsNotNullOrderBySessionDateDesc(
       ClassManagement classManagement, LocalDate sessionDate);
 
+  @Query("""
+    select sum(cs.realClassTime) from ClassSession cs 
+    where cs.classManagement.classMatching.classMatchingId = :matchingId 
+      and cs.cancel is false 
+      and cs.completed is true 
+      and cs.isTodayCancel is false
+      and cs.sessionDate between :startDate and :endDate
+  """)
+  Integer sumClassTime(@Param("matchingId") Long matchingId,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate);
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionQueryService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionQueryService.java
@@ -17,10 +17,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,4 +106,11 @@ public class ClassSessionQueryService {
         now.with(TemporalAdjusters.firstDayOfMonth()),
         now.with(TemporalAdjusters.lastDayOfMonth()));
   }
+
+  @Async
+  public CompletableFuture<Integer> sumClassTimeAsync(ClassMatching matching, LocalDate startDate, LocalDate endDate) {
+    Integer sum = classSessionRepository.sumClassTime(matching.getClassMatchingId(), startDate, endDate);
+    return CompletableFuture.completedFuture(sum != null ? sum : 0);
+  }
+
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/presentation/ClassMatchingScheduleController.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/presentation/ClassMatchingScheduleController.java
@@ -11,6 +11,7 @@ import com.yedu.api.domain.matching.application.dto.req.CompleteSessionTokenRequ
 import com.yedu.api.domain.matching.application.dto.req.CreateScheduleRequest;
 import com.yedu.api.domain.matching.application.dto.res.ClassScheduleMatchingResponse;
 import com.yedu.api.domain.matching.application.dto.res.ClassScheduleRetrieveResponse;
+import com.yedu.api.domain.matching.application.dto.res.RetrieveMonthlyClassTimeResponse;
 import com.yedu.api.domain.matching.application.dto.res.RetrieveScheduleResponse;
 import com.yedu.api.domain.matching.application.dto.res.RetrieveSessionDateResponse;
 import com.yedu.api.domain.matching.application.dto.res.SessionResponse;
@@ -19,6 +20,7 @@ import com.yedu.api.domain.matching.domain.entity.constant.CancelReason;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.PageRequest;
@@ -27,6 +29,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -200,5 +203,24 @@ public class ClassMatchingScheduleController {
     scheduleMatchingUseCase.changeSessionDate(sessionId, changeSessionDateRequest);
 
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/sessions/month")
+  @Operation(
+      summary = "월별 수업 총 진행 시간",
+      description = "월별로 수업 총 실제 수업 진행 시간을 반환합니다",
+      tags = {"완료톡 관련 API"})
+  public ResponseEntity<RetrieveMonthlyClassTimeResponse> retrieveMonthlyClassTime(
+      @RequestParam(required = false) String token,
+      @RequestParam(required = false) Long classMatchingId,
+      @RequestParam(required = false, defaultValue = "2") Integer monthCount
+  ) {
+    if (!StringUtils.hasText(token) && classMatchingId == null){
+      throw new IllegalArgumentException("token 또는 matchingId 중 하나는 필수 값입니다");
+    }
+
+    RetrieveMonthlyClassTimeResponse response = scheduleMatchingUseCase.retrieveMonthlyClassTime(token, classMatchingId, monthCount);
+
+    return ResponseEntity.ok(response);
   }
 }


### PR DESCRIPTION
- 선생님 화면에서 월별로 과외 실제 수업 시간 집계해서 반환해주는 API 입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve total actual class time per month for a class matching, supporting queries by token or classMatchingId and a configurable month range.
  * The monthly class time data is now returned in a structured response, allowing users to view class time statistics for recent months.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->