### PR TITLE
feat : 학부모 과외 일정 조회 API

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.With;
 
 /** 실제 수업 정보 기록 */
 @ToString
@@ -55,6 +56,7 @@ public class ClassSession extends BaseEntity {
 
   private Integer realClassTime;
 
+  @With
   private Integer round; // 회차
 
   private boolean isTodayCancel;

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSessions.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSessions.java
@@ -1,0 +1,57 @@
+package com.yedu.api.domain.matching.domain.entity;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 과외 일정 일급 collection
+ */
+@RequiredArgsConstructor
+public class ClassSessions  {
+
+  private final List<ClassSession> sessions;
+
+  /**
+   * 회차 정보 계산
+   * @param maxRound 최대 회차
+   * @return 회차 정보가 추가된 과외 일정
+   */
+  public List<ClassSession> calculateRoundWithReset(Integer maxRound) {
+    List<ClassSession> sorted = sessions.stream()
+        .sorted(Comparator.comparing(ClassSession::getSessionDate))
+        .toList();
+
+    List<ClassSession> sessionWithRound = new ArrayList<>();
+    // todo 리팩토링
+    int lastRound = 0;
+
+    for (ClassSession session : sorted) {
+      if (session.isCancel() || session.isTodayCancel()) {
+        sessionWithRound.add(session);
+        continue;
+      }
+
+      if (session.isCompleted()) {
+        // 완료된 과외 → 기존 회차 유지
+        if (session.getRound() != null) {
+          lastRound = session.getRound();
+        }
+        sessionWithRound.add(session);
+        continue;
+      }
+
+      // 미완료 → 새 회차
+      int nextRound = lastRound + 1;
+      if (nextRound > maxRound) {
+        nextRound = 1;
+      }
+      lastRound = nextRound;
+
+      sessionWithRound.add(session.withRound(nextRound));
+    }
+
+    return sessionWithRound;
+  }
+}

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassManagementRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassManagementRepository.java
@@ -1,9 +1,11 @@
 package com.yedu.api.domain.matching.domain.repository;
 
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
+import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +24,6 @@ public interface ClassManagementRepository extends JpaRepository<ClassManagement
   @Query(
       "SELECT cm FROM ClassManagement cm JOIN FETCH cm.schedules WHERE cm.classMatching.classMatchingId = :classMatchingId")
   Optional<ClassManagement> findWithSchedule(@Param("classMatchingId") Long classMatchingId);
+
+  List<ClassManagement> findAllByClassMatchingIn(Collection<ClassMatching> classMatchings);
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassMatchingRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassMatchingRepository.java
@@ -3,6 +3,7 @@ package com.yedu.api.domain.matching.domain.repository;
 import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import com.yedu.api.domain.parents.domain.entity.ApplicationForm;
+import com.yedu.api.domain.parents.domain.entity.Parents;
 import com.yedu.api.domain.teacher.domain.entity.Teacher;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Collection;
@@ -42,4 +43,11 @@ public interface ClassMatchingRepository
   void deleteAllByTeacher_TeacherInfo_PhoneNumber(String phoneNumber);
 
   List<ClassMatching> findByTeacherAndMatchStatusIn(Teacher teacher, Collection<MatchingStatus> matchStatuses);
+
+  @Query("""
+    select cm from ClassMatching cm
+      where cm.matchStatus = '최종매칭'
+        and cm.applicationForm.parents = :parents
+  """)
+  List<ClassMatching> findByParent(Parents parents);
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
@@ -41,4 +41,20 @@ public interface ClassSessionRepository
   Integer sumClassTime(@Param("matchingId") Long matchingId,
       @Param("startDate") LocalDate startDate,
       @Param("endDate") LocalDate endDate);
+
+  @Query("""
+  select cs 
+  from ClassSession cs 
+  where cs.classManagement in :classManagements
+    and cs.cancel = false 
+    and cs.isTodayCancel = false 
+    and cs.completed = false 
+    and cs.sessionDate between :startDate and :endDate
+""")
+  List<ClassSession> findSession(
+      @Param("classManagements") List<ClassManagement> classManagements,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate
+  );
+
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassManagementQueryService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassManagementQueryService.java
@@ -2,15 +2,13 @@ package com.yedu.api.domain.matching.domain.service;
 
 import com.yedu.api.domain.matching.application.dto.req.ClassScheduleRetrieveRequest;
 import com.yedu.api.domain.matching.domain.entity.ClassManagement;
+import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import com.yedu.api.domain.matching.domain.repository.ClassManagementRepository;
 import com.yedu.payment.PaymentOperationWrapper;
-import com.yedu.payment.dto.SendBillRequest;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,5 +44,9 @@ public class ClassManagementQueryService {
     return classManagementRepository
         .findAllByRemindIsFalseAndCreatedAtIsLessThanEqualAndClassMatching_MatchStatus(
             LocalDateTime.now().minusDays(1L), MatchingStatus.매칭);
+  }
+
+  public List<ClassManagement> query(List<ClassMatching> matchings) {
+     return classManagementRepository.findAllByClassMatchingIn(matchings);
   }
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassMatchingGetService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassMatchingGetService.java
@@ -4,6 +4,7 @@ import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.constant.MatchingStatus;
 import com.yedu.api.domain.matching.domain.repository.ClassMatchingRepository;
 import com.yedu.api.domain.parents.domain.entity.ApplicationForm;
+import com.yedu.api.domain.parents.domain.entity.Parents;
 import com.yedu.api.domain.teacher.domain.entity.Teacher;
 import com.yedu.api.global.exception.matching.MatchingNotFoundException;
 import java.util.List;
@@ -38,6 +39,9 @@ public class ClassMatchingGetService {
     return classMatchingRepository.findByTeacherAndMatchStatus(teacher, MatchingStatus.최종매칭);
   }
 
+  public List<ClassMatching> getMatched(Parents parent) {
+    return classMatchingRepository.findByParent(parent);
+  }
   public List<ClassMatching> getPaused(Teacher teacher) {
     return classMatchingRepository.findByTeacherAndMatchStatusIn(teacher, List.of(MatchingStatus.일시중단, MatchingStatus.중단));
   }
@@ -47,4 +51,5 @@ public class ClassMatchingGetService {
         .findBySessionId(sessionId)
         .orElseThrow(() -> new IllegalArgumentException("매칭 정보를 찾을수가 없습니다"));
   }
+
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionQueryService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionQueryService.java
@@ -113,4 +113,17 @@ public class ClassSessionQueryService {
     return CompletableFuture.completedFuture(sum != null ? sum : 0);
   }
 
+  public Map<ClassMatching, List<ClassSession>> query(List<ClassMatching> matchings) {
+    List<ClassManagement> managements = classManagementQueryService.query(matchings);
+
+    LocalDate startDate = LocalDate.now();
+    LocalDate endDate = startDate.plusMonths(1).withDayOfMonth(startDate.plusMonths(1).lengthOfMonth());
+
+    List<ClassSession> sessions = classSessionRepository.findSession(managements, startDate, endDate);
+
+    return sessions.stream()
+        .collect(Collectors.groupingBy(
+            cs -> cs.getClassManagement().getClassMatching()
+        ));
+  }
 }

--- a/api/src/main/java/com/yedu/api/domain/parents/application/dto/res/ParentSessionResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/application/dto/res/ParentSessionResponse.java
@@ -1,0 +1,49 @@
+package com.yedu.api.domain.parents.application.dto.res;
+
+import com.yedu.api.domain.matching.domain.entity.ClassMatching;
+import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.matching.domain.entity.ClassSessions;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record ParentSessionResponse(
+    String applicationFormId,
+    String teacherNickname,
+    List<Session> sessions
+    ) {
+
+  @Builder
+  public record Session(
+      Long sessionId,
+      LocalDate sessionDate,
+      Integer roundNumber
+  ){
+
+  }
+
+  public static List<ParentSessionResponse> of(Map<ClassMatching, List<ClassSession>> sessionWithMatching){
+
+    return sessionWithMatching.entrySet().stream().map(entry->{
+      ClassMatching matching = entry.getKey();
+      Integer maxRoundNumber = matching.getApplicationForm().maxRoundNumber();
+      List<ClassSession> sessions = new ClassSessions(entry.getValue()).calculateRoundWithReset(
+          maxRoundNumber);
+
+      List<Session> sessionResponse = sessions.stream().map(it -> Session.builder()
+          .sessionId(it.getClassSessionId())
+          .sessionDate(it.getSessionDate())
+          .roundNumber(it.getRound())
+          .build()).toList();
+
+      return ParentSessionResponse.builder()
+          .applicationFormId(matching.getApplicationForm().getApplicationFormId())
+          .teacherNickname(matching.getTeacher().getTeacherInfo().getNickName())
+          .sessions(sessionResponse)
+          .build();
+    }).toList();
+  }
+
+}

--- a/api/src/main/java/com/yedu/api/domain/parents/presentation/ParentsController.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/presentation/ParentsController.java
@@ -3,14 +3,17 @@ package com.yedu.api.domain.parents.presentation;
 import com.yedu.api.domain.parents.application.dto.req.ApplicationFormRequest;
 import com.yedu.api.domain.parents.application.dto.req.ApplicationFormTimeTableRequest;
 import com.yedu.api.domain.parents.application.dto.res.ApplicationFormTimeTableResponse;
+import com.yedu.api.domain.parents.application.dto.res.ParentSessionResponse;
 import com.yedu.api.domain.parents.application.usecase.ParentsManageUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +45,15 @@ public class ParentsController {
   public ResponseEntity<ApplicationFormTimeTableResponse> retrieveTimeTable(
       @Valid @ParameterObject ApplicationFormTimeTableRequest request) {
     ApplicationFormTimeTableResponse response = parentsManageUseCase.retrieveTimeTable(request);
+
+    return ResponseEntity.ok().body(response);
+  }
+
+
+  @GetMapping("/{phoneNumber}/sessions")
+  @Operation(summary = "학부모의 과외 일정 조회")
+  public ResponseEntity<List<ParentSessionResponse>> retrieveSessions(@PathVariable String phoneNumber) {
+    List<ParentSessionResponse> response = parentsManageUseCase.retrieveSessions(phoneNumber);
 
     return ResponseEntity.ok().body(response);
   }

--- a/api/src/test/java/com/yedu/api/domain/matching/domain/entity/ClassSessionsTest.java
+++ b/api/src/test/java/com/yedu/api/domain/matching/domain/entity/ClassSessionsTest.java
@@ -1,0 +1,93 @@
+package com.yedu.api.domain.matching.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ClassSessionsTest {
+
+  static Stream<TestCase> sessionCases() {
+    LocalDate base = LocalDate.of(2025, 8, 1);
+
+    return Stream.of(
+        // 미완료 + 정상 → 회차 부여됨 (1)
+        new TestCase(
+            List.of(newSession(base.plusDays(1), false, false, false, null)),
+            3,
+            List.of(1)
+        ),
+        // 완료된 과외 있음 → 다음은 이어서 (2)
+        new TestCase(
+            List.of(
+                newSession(base.plusDays(1), true, false, false, 1),
+                newSession(base.plusDays(2), false, false, false, null)
+            ),
+            3,
+            List.of(1, 2)
+        ),
+        // maxRound 초과 → reset
+        new TestCase(
+            List.of(
+                newSession(base.plusDays(1), true, false, false, 3),
+                newSession(base.plusDays(2), false, false, false, null)
+            ),
+            3,
+            List.of(3, 1)
+        ),
+        // 휴강 → 회차 제외
+        new TestCase(
+            List.of(
+                newSession(base.plusDays(1), false, true, false, null),
+                newSession(base.plusDays(2), false, false, false, null)
+            ),
+            3,
+            Arrays.asList(null, 1)
+        ),
+        // 당일휴강 → 회차 제외
+        new TestCase(
+            List.of(
+                newSession(base.plusDays(1), false, false, true, null),
+                newSession(base.plusDays(2), false, false, false, null)
+            ),
+            3,
+            Arrays.asList(null, 1)
+        )
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("sessionCases")
+  void calculateRoundWithReset_should_assign_correct_rounds(TestCase testCase) {
+    // given
+    ClassSessions classSessions = new ClassSessions(testCase.sessions);
+
+    // when
+    List<ClassSession> result = classSessions.calculateRoundWithReset(testCase.maxRound);
+
+    // then
+    List<Integer> actualRounds = result.stream()
+        .map(ClassSession::getRound)
+        .toList();
+
+    assertThat(actualRounds).isEqualTo(testCase.expectedRounds);
+  }
+
+  private static ClassSession newSession(LocalDate date, boolean completed, boolean cancel, boolean todayCancel, Integer round) {
+    return ClassSession.builder()
+        .sessionDate(date)
+        .completed(completed)
+        .cancel(cancel)
+        .isTodayCancel(todayCancel)
+        .round(round)
+        .build();
+  }
+
+  record TestCase(List<ClassSession> sessions, int maxRound, List<Integer> expectedRounds) {
+  }
+}


### PR DESCRIPTION
- 학부모의 과외 일정 조회 용도로 사용할 API 입니다~! 
- `calculateRoundWithReset` 요 로직 조금 지저분한데 차후에 리팩토링 한번하겠습니다~!

<img width="904" height="496" alt="image" src="https://github.com/user-attachments/assets/528cf7b0-87b1-44c1-9596-d790c0cb0ffa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API endpoint for parents to view their tutoring session schedules by phone number.
  * Introduced a new response format for parent session information, including session details and round numbers.
  * Implemented logic to calculate and reset session round numbers based on session status and a maximum round limit.

* **Bug Fixes**
  * Improved handling of session round assignment, ensuring correct sequencing and reset behavior for completed and canceled sessions.

* **Tests**
  * Added comprehensive tests to verify session round calculation and reset logic under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->