### PR TITLE
feat : 학부모 일시정지/교체 신청 접수 API

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/parents/application/dto/req/AcceptChangeSessionRequest.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/application/dto/req/AcceptChangeSessionRequest.java
@@ -1,0 +1,15 @@
+package com.yedu.api.domain.parents.application.dto.req;
+
+import com.yedu.api.domain.parents.domain.entity.constant.Gender;
+import com.yedu.api.domain.parents.domain.entity.constant.Online;
+import com.yedu.api.domain.parents.domain.entity.constant.SessionChangeType;
+import com.yedu.api.domain.parents.domain.vo.DayTime;
+import com.yedu.common.type.ClassType;
+import java.util.List;
+
+public record AcceptChangeSessionRequest(
+    Long sessionId,
+    SessionChangeType type
+) {
+
+}

--- a/api/src/main/java/com/yedu/api/domain/parents/application/usecase/ParentsManageUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/application/usecase/ParentsManageUseCase.java
@@ -7,6 +7,7 @@ import com.yedu.api.domain.matching.domain.entity.ClassMatching;
 import com.yedu.api.domain.matching.domain.entity.ClassSession;
 import com.yedu.api.domain.matching.domain.service.ClassMatchingGetService;
 import com.yedu.api.domain.matching.domain.service.ClassSessionQueryService;
+import com.yedu.api.domain.parents.application.dto.req.AcceptChangeSessionRequest;
 import com.yedu.api.domain.parents.application.dto.req.ApplicationFormRequest;
 import com.yedu.api.domain.parents.application.dto.req.ApplicationFormTimeTableRequest;
 import com.yedu.api.domain.parents.application.dto.res.ApplicationFormTimeTableResponse;
@@ -22,6 +23,7 @@ import com.yedu.api.domain.parents.domain.service.ApplicationFormAvailableQueryS
 import com.yedu.api.domain.parents.domain.service.ParentsGetService;
 import com.yedu.api.domain.parents.domain.service.ParentsSaveService;
 import com.yedu.api.domain.parents.domain.service.ParentsUpdateService;
+import com.yedu.api.domain.parents.domain.service.SessionChangeFormCommandService;
 import com.yedu.api.domain.teacher.application.usecase.TeacherInfoUseCase;
 import com.yedu.api.domain.teacher.application.usecase.TeacherManageUseCase;
 import com.yedu.api.domain.teacher.domain.aggregate.TeacherWithAvailable;
@@ -53,8 +55,9 @@ public class ParentsManageUseCase {
   private final ApplicationFormRepository applicationFormRepository;
   private final ClassMatchingGetService classMatchingGetService;
   private final ClassSessionQueryService classSessionQueryService;
+  private final SessionChangeFormCommandService sessionChangeFormCommandService;
 
-  
+
   public void saveParentsAndApplication(ApplicationFormRequest request, boolean isResend) {
     
     Parents parents =
@@ -149,5 +152,12 @@ public class ParentsManageUseCase {
     Map<ClassMatching, List<ClassSession>> sessionWithMatching = classSessionQueryService.query(matchings);
 
     return ParentSessionResponse.of(sessionWithMatching);
+  }
+
+  public void acceptChangeSessionForm(String phoneNumber, AcceptChangeSessionRequest request) {
+    Parents parent = parentsGetService.optionalParentsByPhoneNumber(phoneNumber)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학부모 핸드폰번호입니다."));
+
+    sessionChangeFormCommandService.save(parent, request);
   }
 }

--- a/api/src/main/java/com/yedu/api/domain/parents/domain/entity/SessionChangeForm.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/domain/entity/SessionChangeForm.java
@@ -1,0 +1,45 @@
+package com.yedu.api.domain.parents.domain.entity;
+
+import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.parents.domain.entity.constant.SessionChangeType;
+import com.yedu.api.global.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SessionChangeForm extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parents_id")
+  private Parents parents;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "session_id")
+  private ClassSession lastSessionBeforeChange;
+
+  @Enumerated(EnumType.STRING)
+  private SessionChangeType changeType;
+
+
+}

--- a/api/src/main/java/com/yedu/api/domain/parents/domain/entity/constant/SessionChangeType.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/domain/entity/constant/SessionChangeType.java
@@ -1,0 +1,6 @@
+package com.yedu.api.domain.parents.domain.entity.constant;
+
+public enum SessionChangeType {
+  PAUSE,
+  CHANGE_TEACHER
+}

--- a/api/src/main/java/com/yedu/api/domain/parents/domain/repository/SessionChangeFormRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/domain/repository/SessionChangeFormRepository.java
@@ -1,0 +1,10 @@
+package com.yedu.api.domain.parents.domain.repository;
+
+import com.yedu.api.domain.parents.domain.entity.SessionChangeForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SessionChangeFormRepository extends JpaRepository<SessionChangeForm, Long> {
+
+}

--- a/api/src/main/java/com/yedu/api/domain/parents/domain/service/SessionChangeFormCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/domain/service/SessionChangeFormCommandService.java
@@ -1,0 +1,32 @@
+package com.yedu.api.domain.parents.domain.service;
+
+import com.yedu.api.domain.matching.domain.entity.ClassSession;
+import com.yedu.api.domain.matching.domain.repository.ClassSessionRepository;
+import com.yedu.api.domain.parents.application.dto.req.AcceptChangeSessionRequest;
+import com.yedu.api.domain.parents.domain.entity.Parents;
+import com.yedu.api.domain.parents.domain.entity.SessionChangeForm;
+import com.yedu.api.domain.parents.domain.repository.SessionChangeFormRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = false)
+public class SessionChangeFormCommandService {
+
+  private final SessionChangeFormRepository sessionChangeFormRepository;
+  private final ClassSessionRepository classSessionRepository;
+
+  public void save(Parents parents, AcceptChangeSessionRequest request) {
+    ClassSession session = classSessionRepository.findById(request.sessionId()).orElseThrow();
+
+    SessionChangeForm sessionChangeForm = SessionChangeForm.builder()
+        .lastSessionBeforeChange(session)
+        .parents(parents)
+        .changeType(request.type())
+        .build();
+
+    sessionChangeFormRepository.save(sessionChangeForm);
+  }
+}

--- a/api/src/main/java/com/yedu/api/domain/parents/presentation/ParentsController.java
+++ b/api/src/main/java/com/yedu/api/domain/parents/presentation/ParentsController.java
@@ -1,5 +1,6 @@
 package com.yedu.api.domain.parents.presentation;
 
+import com.yedu.api.domain.parents.application.dto.req.AcceptChangeSessionRequest;
 import com.yedu.api.domain.parents.application.dto.req.ApplicationFormRequest;
 import com.yedu.api.domain.parents.application.dto.req.ApplicationFormTimeTableRequest;
 import com.yedu.api.domain.parents.application.dto.res.ApplicationFormTimeTableResponse;
@@ -56,5 +57,13 @@ public class ParentsController {
     List<ParentSessionResponse> response = parentsManageUseCase.retrieveSessions(phoneNumber);
 
     return ResponseEntity.ok().body(response);
+  }
+
+  @PostMapping("/{phoneNumber}/sessions/change-form")
+  @Operation(summary = "학부모의 과외 일시정지/교체 신청 접수")
+  public ResponseEntity<Void> acceptChangeSessionForm(@PathVariable String phoneNumber, @RequestBody AcceptChangeSessionRequest acceptChangeSessionRequest) {
+    parentsManageUseCase.acceptChangeSessionForm(phoneNumber, acceptChangeSessionRequest);
+
+    return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/resources/db/migration/V6_202508061800__create_parent_session_change_form_table.sql
+++ b/api/src/main/resources/db/migration/V6_202508061800__create_parent_session_change_form_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS yedu.session_change_form (
+     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+     parents_id BIGINT,
+     session_id BIGINT,
+     change_type VARCHAR(50),
+     created_at  datetime(6)                                                                                                                                                                                                                                  null,
+     updated_at  datetime(6)
+);


### PR DESCRIPTION
일시정지/교체 신청 접수를 위한 API입니다. 

<img width="535" height="400" alt="image" src="https://github.com/user-attachments/assets/a3f835f3-553b-4bed-8429-088eb11253d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for parents to submit requests to pause or change tutoring sessions.
  * Introduced support for handling and recording session change requests, including options to pause or change the assigned teacher.
  * Session change requests are now stored and tracked in the system for improved management and follow-up.

* **Database**
  * Added a new table to store session change request details, including parent, session, type of change, and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->