### PR TITLE
Feature/today cancel

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
@@ -71,8 +71,14 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules, Map<String, M
                 .classStart(it.getClassTime().getStart())
                 .understanding(it.getUnderstanding())
                 .homework(it.getHomework())
-                .currentRound(Optional.ofNullable(it.getRound())
-                    .orElse(roundMap.get(it.getClassSessionId())))
+                .currentRound(
+                    Optional.ofNullable(it.getTeacherRound())
+                        .filter(r -> r != 0)
+                        .orElseGet(() -> {
+                            Integer roundValue = roundMap.get(it.getClassSessionId());
+                            return (roundValue != null && roundValue != 0) ? roundValue : null;
+                        })
+                )
                 .maxRound(maxRound)
                 .classMinute(it.isCompleted() ? it.getRealClassTime() : it.getClassTime().getClassMinute())
                 .build());

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
@@ -288,7 +288,7 @@ public class ClassScheduleMatchingUseCase {
       throw new IllegalStateException("휴강되거나 당일 취소된 세션은 날짜를 변경할 수 없습니다");
     }
 
-    // 날짜 변경 후 round 순차 업데이트
+    // 날짜 변경 후 회차 순차 업데이트
     classSessionCommandService.updateRoundSequentially(sessionId);
 
     ClassManagement classManagement = session.getClassManagement();
@@ -342,11 +342,6 @@ public class ClassScheduleMatchingUseCase {
   public void revertCancelSession(Long sessionId) {
     ClassSession session = classSessionCommandService.revertCancel(sessionId);
     
-    // Teacher 취소 철회인 경우 round 순차 업데이트
-    if (CancelReason.TEACHER.name().equals(session.getCancelReason())) {
-      classSessionCommandService.updateRoundSequentially(sessionId);
-    }
-
     ClassManagement classManagement = session.getClassManagement();
     ClassMatching matching = classManagement.getClassMatching();
     TeacherInfo teacherInfo = matching.getTeacher().getTeacherInfo();
@@ -427,10 +422,11 @@ public class ClassScheduleMatchingUseCase {
         .map(classMatchingGetService::getBySessionId)
         .orElseGet(
             () -> {
-              Long matchingId = classMatchingKeyStorage.get(token);
-              if (matchingId == null) {
-                throw new IllegalArgumentException("잘못된 토큰값입니다");
-              }
+              // Long matchingId = classMatchingKeyStorage.get(token);
+              // if (matchingId == null) {
+              //   throw new IllegalArgumentException("잘못된 토큰값입니다");
+              // }
+              Long matchingId = 2257L;
               return classMatchingGetService.getById(matchingId);
             });
   }

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
@@ -422,10 +422,12 @@ public class ClassScheduleMatchingUseCase {
         .map(classMatchingGetService::getBySessionId)
         .orElseGet(
             () -> {
-              Long matchingId = classMatchingKeyStorage.get(token);
-              if (matchingId == null) {
-                throw new IllegalArgumentException("잘못된 토큰값입니다");
-              }
+              // Long matchingId = classMatchingKeyStorage.get(token);
+              // if (matchingId == null) {
+              //   throw new IllegalArgumentException("잘못된 토큰값입니다");
+              // }
+
+              Long matchingId = 2257L;
               return classMatchingGetService.getById(matchingId);
             });
   }

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
@@ -422,11 +422,10 @@ public class ClassScheduleMatchingUseCase {
         .map(classMatchingGetService::getBySessionId)
         .orElseGet(
             () -> {
-              // Long matchingId = classMatchingKeyStorage.get(token);
-              // if (matchingId == null) {
-              //   throw new IllegalArgumentException("잘못된 토큰값입니다");
-              // }
-              Long matchingId = 2257L;
+              Long matchingId = classMatchingKeyStorage.get(token);
+              if (matchingId == null) {
+                throw new IllegalArgumentException("잘못된 토큰값입니다");
+              }
               return classMatchingGetService.getById(matchingId);
             });
   }

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassScheduleMatchingUseCase.java
@@ -282,6 +282,15 @@ public class ClassScheduleMatchingUseCase {
         request.sessionDate(),
         request.start());
     ClassSession session = changeInfo.getKey();
+
+    // 휴강된 세션이거나 당일 취소된 세션인 경우 에러 발생
+    if (session.isCancel() || session.isTodayCancel()) {
+      throw new IllegalStateException("휴강되거나 당일 취소된 세션은 날짜를 변경할 수 없습니다");
+    }
+
+    // 날짜 변경 후 round 순차 업데이트
+    classSessionCommandService.updateRoundSequentially(sessionId);
+
     ClassManagement classManagement = session.getClassManagement();
     ClassMatching matching = classManagement.getClassMatching();
     TeacherInfo teacherInfo = matching.getTeacher().getTeacherInfo();
@@ -304,6 +313,12 @@ public class ClassScheduleMatchingUseCase {
 
   public void cancelSession(Long sessionId, CancelSessionRequest cancelSessionRequest) {
     ClassSession session = classSessionCommandService.cancel(sessionId, cancelSessionRequest.cancelReason(), cancelSessionRequest.isTodayCancel());
+    
+    // Teacher 취소인 경우 round 순차 업데이트
+    if (cancelSessionRequest.cancelReason() == CancelReason.TEACHER) {
+      classSessionCommandService.updateRoundSequentially(sessionId);
+    }
+
     ClassManagement classManagement = session.getClassManagement();
     ClassMatching matching = classManagement.getClassMatching();
     TeacherInfo teacherInfo = matching.getTeacher().getTeacherInfo();
@@ -326,6 +341,12 @@ public class ClassScheduleMatchingUseCase {
 
   public void revertCancelSession(Long sessionId) {
     ClassSession session = classSessionCommandService.revertCancel(sessionId);
+    
+    // Teacher 취소 철회인 경우 round 순차 업데이트
+    if (CancelReason.TEACHER.name().equals(session.getCancelReason())) {
+      classSessionCommandService.updateRoundSequentially(sessionId);
+    }
+
     ClassManagement classManagement = session.getClassManagement();
     ClassMatching matching = classManagement.getClassMatching();
     TeacherInfo teacherInfo = matching.getTeacher().getTeacherInfo();

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
@@ -59,6 +59,8 @@ public class ClassSession extends BaseEntity {
 
   private boolean isTodayCancel;
 
+  private Integer teacherRound;
+
   public void cancel(String cancelReason, boolean isTodayCancel) {
     if (cancel) {
       throw new IllegalStateException("이미 취소된 일정입니다");

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -41,4 +42,23 @@ public interface ClassSessionRepository
   Integer sumClassTime(@Param("matchingId") Long matchingId,
       @Param("startDate") LocalDate startDate,
       @Param("endDate") LocalDate endDate);
+
+  @Query("""
+    select cs from ClassSession cs
+    where cs.classManagement.classManagementId = (
+      select cs2.classManagement.classManagementId
+      from ClassSession cs2
+      where cs2.classSessionId = :sessionId
+    )
+    order by cs.sessionDate asc
+  """)
+  List<ClassSession> findBySameClassManagementId(@Param("sessionId") Long sessionId);
+
+  @Query("""
+    UPDATE ClassSession cs
+    SET cs.round = :round
+    WHERE cs.classSessionId = :sessionId
+  """)
+  @Modifying
+  void updateRoundBySessionId(@Param("sessionId") Long sessionId, @Param("round") Integer round);
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepository.java
@@ -56,9 +56,17 @@ public interface ClassSessionRepository
 
   @Query("""
     UPDATE ClassSession cs
-    SET cs.round = :round
+    SET cs.teacherRound = :teacherRound
     WHERE cs.classSessionId = :sessionId
   """)
   @Modifying
-  void updateRoundBySessionId(@Param("sessionId") Long sessionId, @Param("round") Integer round);
+  void updateRoundBySessionId(@Param("sessionId") Long sessionId, @Param("teacherRound") Integer teacherRound);
+
+  @Query("""
+    SELECT COALESCE(MAX(cs.teacherRound), 0)
+    FROM ClassSession cs
+    WHERE cs.classManagement.classMatching.classMatchingId = :matchingId
+      AND cs.teacherRound IS NOT NULL
+  """)
+  Integer findMaxRoundByMatchingId(@Param("matchingId") Long matchingId);
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepositoryImpl.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/repository/ClassSessionRepositoryImpl.java
@@ -95,7 +95,7 @@ public class ClassSessionRepositoryImpl implements CustomClassSessionRepository 
                         .and(classSession.cancel.isFalse())
                 )
                 .or(
-                    classSession.sessionDate.between(now.minusDays(7), endDate)
+                    classSession.sessionDate.between(now.minusDays(14), endDate)
                 )
         )
         .and(

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
@@ -182,29 +182,11 @@ public class ClassSessionCommandService {
 
     for (ClassSession session : sessions) {
       if (session.isTodayCancel() && CancelReason.TEACHER.name().equals(session.getCancelReason())) {
-        // Teacher 취소인 경우 round가 null이면 이전 회차 + 1 계산
-        if (session.getRound() == null) {
-          // 이전 완료된 세션의 round를 찾아서 + 1
-          Optional<ClassSession> prevCompletedSession = classSessionRepository
-              .findFirstByClassManagementAndSessionDateBeforeAndCompletedTrueAndCancelFalseAndRoundIsNotNullOrderBySessionDateDesc(
-                  session.getClassManagement(), session.getSessionDate());
-          
-          if (prevCompletedSession.isPresent()) {
-            Integer prevRound = prevCompletedSession.get().getRound();
-            teacherCancelRound = prevRound + 1;
-            classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), teacherCancelRound);
-          } else {
-            // 이전 완료된 세션이 없으면 1로 설정
-            teacherCancelRound = 1;
-            classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), teacherCancelRound);
-          }
-        } else {
-          // round가 이미 있으면 그대로 유지
-          teacherCancelRound = session.getRound();
-        }
+        // round가 이미 있으면 그대로 유지
+        teacherCancelRound = session.getRound();
         afterTeacherCancel = true;
         isNextAfterTeacherCancel = true;
-      } else if (afterTeacherCancel) { // Only update sessions AFTER a teacher cancel
+      } else if (afterTeacherCancel) {
         if (isNextAfterTeacherCancel) {
           // Teacher 취소 다음 세션은 무조건 0
           classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), 0);
@@ -215,7 +197,6 @@ public class ClassSessionCommandService {
           roundCounter++;
         }
       }
-      // Teacher 취소 전 세션들은 기존 round 유지 (변경하지 않음)
     }
   }
 

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
@@ -176,41 +176,64 @@ public class ClassSessionCommandService {
       return;
     }
     
-    // matchingId 조회
     Long matchingId = sessions.get(0).getClassManagement().getClassMatching().getClassMatchingId();
-    
-    // maxRound 조회
     Integer maxRound = classSessionRepository.findMaxRoundByMatchingId(matchingId);
-
+    
     Integer teacherCancelRound = 0;
     boolean afterTeacherCancel = false;
     boolean isNextAfterTeacherCancel = false;
     int roundCounter = 1;
 
     for (ClassSession session : sessions) {
-      if (session.isTodayCancel() && CancelReason.TEACHER.name().equals(session.getCancelReason())) {
-        // round가 이미 있으면 그대로 유지
-        teacherCancelRound = session.getTeacherRound() != null && session.getTeacherRound() != 0 ? session.getTeacherRound() : 0;
+      if (isTeacherCancel(session)) {
+        // Teacher 취소: 기존 round 유지
+        teacherCancelRound = getValidTeacherRound(session);
         afterTeacherCancel = true;
         isNextAfterTeacherCancel = true;
+      } else if (isOtherCancel(session)) {
+        // 다른 이유로 취소: round 순차 증가
+        updateRound(session, teacherCancelRound + roundCounter, maxRound);
+        roundCounter = getNextRoundCounter(roundCounter, teacherCancelRound + roundCounter, maxRound);
       } else if (afterTeacherCancel) {
         if (isNextAfterTeacherCancel) {
-          // Teacher 취소 다음 세션은 무조건 0
+          // Teacher 취소 다음 세션: round = 0
           classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), 0);
           isNextAfterTeacherCancel = false;
         } else {
-          // Teacher 취소 다다음 세션부터는 Teacher 취소 round + 1부터 시작하되, maxRound를 넘지 않도록
-          int newRound = teacherCancelRound + roundCounter;
-          if (newRound < maxRound) {
-            classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), newRound);
-            roundCounter++;
-          } else {
-            // maxRound에 도달하거나 초과하면 1부터 다시 시작
-            classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), 1);
-            roundCounter = 2; // 다음부터는 2, 3, 4... 순으로 증가
-          }
+          // Teacher 취소 다다음 세션부터: round 순차 증가
+          updateRound(session, teacherCancelRound + roundCounter, maxRound);
+          roundCounter = getNextRoundCounter(roundCounter, teacherCancelRound + roundCounter, maxRound);
         }
       }
+    }
+  }
+  
+  private boolean isTeacherCancel(ClassSession session) {
+    return session.isTodayCancel() && CancelReason.TEACHER.name().equals(session.getCancelReason());
+  }
+  
+  private boolean isOtherCancel(ClassSession session) {
+    return session.isTodayCancel() && !CancelReason.TEACHER.name().equals(session.getCancelReason());
+  }
+  
+  private Integer getValidTeacherRound(ClassSession session) {
+    Integer teacherRound = session.getTeacherRound();
+    return teacherRound != null && teacherRound != 0 ? teacherRound : 0;
+  }
+  
+  private void updateRound(ClassSession session, int newRound, Integer maxRound) {
+    if (newRound < maxRound) {
+      classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), newRound);
+    } else {
+      classSessionRepository.updateRoundBySessionId(session.getClassSessionId(), 1);
+    }
+  }
+  
+  private int getNextRoundCounter(int currentCounter, int newRound, Integer maxRound) {
+    if (newRound < maxRound) {
+      return currentCounter + 1;
+    } else {
+      return 2; // 1부터 다시 시작하므로 다음은 2
     }
   }
 }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
@@ -183,7 +183,7 @@ public class ClassSessionCommandService {
     for (ClassSession session : sessions) {
       if (session.isTodayCancel() && CancelReason.TEACHER.name().equals(session.getCancelReason())) {
         // round가 이미 있으면 그대로 유지
-        teacherCancelRound = session.getRound();
+        teacherCancelRound = session.getRound() != null ? session.getRound() : 0;
         afterTeacherCancel = true;
         isNextAfterTeacherCancel = true;
       } else if (afterTeacherCancel) {

--- a/shared/sheet-support/src/main/java/com/yedu/sheet/support/MockSheetService.java
+++ b/shared/sheet-support/src/main/java/com/yedu/sheet/support/MockSheetService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@Profile({"local"})
+@Profile({"local", "default"})
 public class MockSheetService implements SheetApi {
 
   @Override


### PR DESCRIPTION
##  **변경 영향 API**
- **과외 일정 조회 API**: `POST /sessions`
- **세션 취소 API**: `PATCH /sessions/{sessionId}/cancel`
- **세션 날짜 변경 API**: `PATCH /sessions/{sessionId}/change`

## 변경사항 요약

### 1. **추가**
- **currentRound** 필드 내부 변경
    - round -> teacherRound

- **Repository에 maxRound 조회 메서드 추가**
  ```java
  Integer findMaxRoundByMatchingId(@Param("matchingId") Long matchingId);
  ```

- **다른 이유로 당일 휴강된 경우 round 순차 증가 로직 추가**
  ```java
  else if (isOtherCancel(session)) {
    // Teacher가 아닌 다른 이유로 취소된 경우도 round 순차 증가
  }
  ```

- **maxRound 제한 로직 추가**
  ```java
  if (newRound < maxRound) {
    // 계속 증가
  } else {
    // 1부터 다시 시작
  }
  ```

- **matchingId 조회 및 maxRound 조회 로직 추가**
  ```java
  Long matchingId = sessions.get(0).getClassManagement().getClassMatching().getClassMatchingId();
  Integer maxRound = classSessionRepository.findMaxRoundByMatchingId(matchingId);
  ```

### 2. **변경**
- **null 체크 로직 변경**
  ```java
  // 기존: null만 체크
  teacherCancelRound = session.getTeacherRound() != null ? session.getTeacherRound() : 0;
  
  // 변경: null과 0 모두 체크
  teacherCancelRound = session.getTeacherRound() != null && session.getTeacherRound() != 0 
      ? session.getTeacherRound() : 0;
  ```

- **updateRoundSequentially 메서드 구조 변경**
  - 변경: 여러 개의 간단한 private 메서드로 분리

- **round 증가 로직 변경**
  - 변경: maxRound까지 증가 후 1부터 다시 시작

- **Teacher 취소 이후 처리 로직 변경**
  - 변경: Teacher 취소 + 다른 취소 모두 처리

- **휴강일 경우 보여지는 조건 7 -> 14일로 로직 변경**

