### PR TITLE
(당일휴강)maxRound 필드 추가 관련 로직 수정

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/dto/res/SessionResponse.java
@@ -71,15 +71,8 @@ public record SessionResponse(Map<String, ScheduleInfo> schedules, Map<String, M
                 .classStart(it.getClassTime().getStart())
                 .understanding(it.getUnderstanding())
                 .homework(it.getHomework())
-                .currentRound(
-                    Optional.ofNullable(it.getTeacherRound())
-                        .filter(r -> r != 0)
-                        .orElseGet(() -> {
-                            Integer roundValue = roundMap.get(it.getClassSessionId());
-                            return (roundValue != null && roundValue != 0) ? roundValue : null;
-                        })
-                )
-                .maxRound(maxRound)
+                .currentRound(it.getTeacherRound())
+                .maxRound(it.getMaxRound())
                 .classMinute(it.isCompleted() ? it.getRealClassTime() : it.getClassTime().getClassMinute())
                 .build());
   }

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/entity/ClassSession.java
@@ -63,6 +63,8 @@ public class ClassSession extends BaseEntity {
 
   private Integer teacherRound;
 
+  private Integer maxRound;
+
   public void cancel(String cancelReason, boolean isTodayCancel) {
     if (cancel) {
       throw new IllegalStateException("이미 취소된 일정입니다");

--- a/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/domain/service/ClassSessionCommandService.java
@@ -176,8 +176,7 @@ public class ClassSessionCommandService {
       return;
     }
     
-    Long matchingId = sessions.get(0).getClassManagement().getClassMatching().getClassMatchingId();
-    Integer maxRound = classSessionRepository.findMaxRoundByMatchingId(matchingId);
+    Integer maxRound = sessions.get(0).getMaxRound();
     
     Integer teacherCancelRound = 0;
     boolean afterTeacherCancel = false;

--- a/api/src/main/resources/db/migration/V8_202508080548__add_max_round_column.sql
+++ b/api/src/main/resources/db/migration/V8_202508080548__add_max_round_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE class_session
+    ADD COLUMN max_round INT DEFAULT 0 COMMENT '월 최대 회차 정보';


### PR DESCRIPTION
영향도 API 
- 과외 일정 조회 API:  PUT: sessions
- 시간/날짜 등록된 알림톡 발송 API: /teacher/request/complete-talk/with-schedule

- 주요 변경사항
maxRound 추가
generateNewSessions 함수 내부 maxRound, teacherRound 데이터 삽입 로직 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field to display the maximum number of rounds per month for each class session.

* **Improvements**
  * Enhanced scheduling logic to automatically assign and display the correct round information for sessions based on class frequency.
  * Improved performance by reducing unnecessary database queries related to session rounds.

* **Database**
  * Added a new column to store monthly maximum round information for class sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->