### PR TITLE
hotfix : npe 방지

### DIFF
--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
@@ -295,10 +295,7 @@ public class ClassMatchingInfoUseCase {
                                 it ->
                                     ApplicationFormResponse.Session.builder()
                                         .classSessionId(it.getClassSessionId())
-                                        .date(Optional.ofNullable(it.getSessionDate())
-                                                .map(LocalDate::toString)
-                                                .orElse(null)
-                                        )
+                                        .date(it.getSessionDate().toString())
                                         .start(Optional.ofNullable(it.getClassTime())
                                                 .map(ClassTime::getStart)
                                                 .map(LocalTime::toString)

--- a/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
+++ b/api/src/main/java/com/yedu/api/domain/matching/application/usecase/ClassMatchingInfoUseCase.java
@@ -14,6 +14,7 @@ import com.yedu.api.domain.matching.domain.repository.ClassMatchingRepository;
 import com.yedu.api.domain.matching.domain.service.ClassManagementQueryService;
 import com.yedu.api.domain.matching.domain.service.ClassMatchingGetService;
 import com.yedu.api.domain.matching.domain.service.ClassSessionQueryService;
+import com.yedu.api.domain.matching.domain.vo.ClassTime;
 import com.yedu.api.domain.parents.domain.entity.ApplicationForm;
 import com.yedu.api.domain.parents.domain.entity.ApplicationFormAvailable;
 import com.yedu.api.domain.parents.domain.entity.Goal;
@@ -294,8 +295,15 @@ public class ClassMatchingInfoUseCase {
                                 it ->
                                     ApplicationFormResponse.Session.builder()
                                         .classSessionId(it.getClassSessionId())
-                                        .date(it.getSessionDate().toString())
-                                        .start(it.getClassTime().getStart().toString())
+                                        .date(Optional.ofNullable(it.getSessionDate())
+                                                .map(LocalDate::toString)
+                                                .orElse(null)
+                                        )
+                                        .start(Optional.ofNullable(it.getClassTime())
+                                                .map(ClassTime::getStart)
+                                                .map(LocalTime::toString)
+                                                .orElse(null)
+                                        )
                                         .classMinute(it.getClassTime().getClassMinute())
                                         .realClassMinute(it.getRealClassTime())
                                         .understanding(it.getUnderstanding())


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
hotfix : npe 방지

## ✨ PR 상세
graphql 응답 중 예외 발생
-> 로그 확인해보니, NPE가 발생하고 있었음
<img width="1527" height="74" alt="image" src="https://github.com/user-attachments/assets/c9b3dd3c-d55b-443d-8020-5aaa26c11d77" />
확인 결과, 대부분의 경우 Optional과 Wrapper클래스 등을 활용하여 Null을 방지하고 있었지만, LocalDate에서 `.toString` 을 하는 과정에서 `null.toString` 이 되어 NPE가 발생한 것으로 추정됨.
-> 실제로 classSession 테이블에 start값이 null인 classMange가 총 5개 있었고, 5개의 값이 예외를 일으키고 있었음.

기존의 코드 스타일이 Optional을 활용하는 것으로 보여, 최대한 이를 깨뜨리지 않고자 `Opional.ofNullable` 로 감싸서 처리하고자 했습니다..!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
start이외의 값들은 기본적으로 무조건 생성되는 값으로 보여 null처리를 하지 않았습니다.
만약 Null 가능성이 있다면 추가로 처리하거나 하는 과정이 필요할 듯 싶습니다..!

근데, 여담이지만 Grafana 가 바꼈던데, 실시간으로 에러 로그가 확인되지 않아요..! 도커에서 -f --tail 1000 해서 확인했어요...

## ✅ 체크리스트
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
